### PR TITLE
fix: persist dark mode preference across page refreshes

### DIFF
--- a/src/store/appStore.ts
+++ b/src/store/appStore.ts
@@ -66,7 +66,10 @@ export const useAppStore = create<AppState>((set, get) => ({
   highlightedEntities: [],
   highlightedRelationships: [],
   showDataBindings: false,
-  darkMode: true,
+  darkMode: (() => {
+    const stored = localStorage.getItem('darkMode');
+    return stored !== null ? stored === 'true' : true;
+  })(),
   
   // Initial Quest State - use default quests for Cosmic Coffee
   availableQuests: defaultQuests,
@@ -132,7 +135,11 @@ export const useAppStore = create<AppState>((set, get) => ({
   setHighlightedRelationships: (ids) => set({ highlightedRelationships: ids }),
   
   toggleDataBindings: () => set((state) => ({ showDataBindings: !state.showDataBindings })),
-  toggleDarkMode: () => set((state) => ({ darkMode: !state.darkMode })),
+  toggleDarkMode: () => set((state) => {
+    const next = !state.darkMode;
+    localStorage.setItem('darkMode', String(next));
+    return { darkMode: next };
+  }),
   
   // Quest Actions
   startQuest: (questId) => {

--- a/src/store/appStore.ts
+++ b/src/store/appStore.ts
@@ -67,8 +67,25 @@ export const useAppStore = create<AppState>((set, get) => ({
   highlightedRelationships: [],
   showDataBindings: false,
   darkMode: (() => {
-    const stored = localStorage.getItem('darkMode');
-    return stored !== null ? stored === 'true' : true;
+    // Safely read dark mode preference; default to true if unavailable or invalid
+    if (typeof window === 'undefined' || !('localStorage' in window)) {
+      return true;
+    }
+
+    try {
+      const stored = window.localStorage.getItem('darkMode');
+      if (stored === 'true') {
+        return true;
+      }
+      if (stored === 'false') {
+        return false;
+      }
+      // Treat unexpected values as unset
+      return true;
+    } catch {
+      // Handles SecurityError and other storage-related issues
+      return true;
+    }
   })(),
   
   // Initial Quest State - use default quests for Cosmic Coffee

--- a/src/store/appStore.ts
+++ b/src/store/appStore.ts
@@ -154,7 +154,11 @@ export const useAppStore = create<AppState>((set, get) => ({
   toggleDataBindings: () => set((state) => ({ showDataBindings: !state.showDataBindings })),
   toggleDarkMode: () => set((state) => {
     const next = !state.darkMode;
-    localStorage.setItem('darkMode', String(next));
+    try {
+      localStorage.setItem('darkMode', String(next));
+    } catch {
+      // Ignore persistence errors; still update in-memory state
+    }
     return { darkMode: next };
   }),
   


### PR DESCRIPTION
- Read darkMode from localStorage on store initialization (default: true)
- Write darkMode to localStorage on every toggle
- Previously darkMode was hardcoded to true, resetting on refresh

@videlalvaro