### PR TITLE
fix: filter out relationships with unresolved source or target in RDF…

### DIFF
--- a/src/components/OntologyGraph.tsx
+++ b/src/components/OntologyGraph.tsx
@@ -75,17 +75,21 @@ export function OntologyGraph() {
       }
     }));
 
-    const edges = currentOntology.relationships.map(rel => ({
-      data: {
-        id: rel.id,
-        source: rel.from,
-        target: rel.to,
-        label: rel.name,
-        cardinality: rel.cardinality,
-        description: rel.description,
-        type: 'relationship'
-      }
-    }));
+    const nodeIds = new Set(nodes.map(n => n.data.id));
+
+    const edges = currentOntology.relationships
+      .filter(rel => rel.from && rel.to && nodeIds.has(rel.from) && nodeIds.has(rel.to))
+      .map(rel => ({
+        data: {
+          id: rel.id,
+          source: rel.from,
+          target: rel.to,
+          label: rel.name,
+          cardinality: rel.cardinality,
+          description: rel.description,
+          type: 'relationship'
+        }
+      }));
 
     return [...nodes, ...edges];
   }, [currentOntology]);

--- a/src/lib/rdf/parser.ts
+++ b/src/lib/rdf/parser.ts
@@ -315,6 +315,9 @@ export function parseRDF(rdfXml: string): { ontology: Ontology; bindings: DataBi
       rel.attributes = attrs;
     }
 
+    // Skip relationships with unresolved source or target
+    if (!rel.from || !rel.to) continue;
+
     relationships.push(rel);
   }
 


### PR DESCRIPTION
This pull request improves the robustness of the ontology graph by ensuring that only valid relationships with resolved source and target nodes are included in both the data parsing and visualization stages. These changes help prevent errors or inconsistencies caused by relationships that reference nonexistent nodes.

**Ontology relationship validation:**

* In `src/lib/rdf/parser.ts`, the RDF parser now skips relationships that do not have both a source (`from`) and target (`to`) node, preventing unresolved relationships from being added to the ontology data.
* In `src/components/OntologyGraph.tsx`, the graph visualization filters out relationships whose endpoints are not present in the current set of nodes, ensuring only valid edges are rendered.