### PR TITLE
fix: property-type quest steps never complete (fixes #21)

### DIFF
--- a/src/components/InspectorPanel.tsx
+++ b/src/components/InspectorPanel.tsx
@@ -2,7 +2,7 @@ import { useAppStore } from '../store/appStore';
 import { Database, ArrowRight, Key, Link2, Layers, Box, GitBranch } from 'lucide-react';
 
 export function InspectorPanel() {
-  const { currentOntology, dataBindings, selectedEntityId, selectedRelationshipId, showDataBindings } = useAppStore();
+  const { currentOntology, dataBindings, selectedEntityId, selectedRelationshipId, showDataBindings, activeQuest, currentStepIndex, advanceQuestStep } = useAppStore();
 
   if (!selectedEntityId && !selectedRelationshipId) {
     return (
@@ -121,7 +121,14 @@ export function InspectorPanel() {
           </div>
           <div className="property-list">
             {entity.properties.map(prop => (
-              <div key={prop.name} className="property-item">
+              <div key={prop.name} className="property-item" style={{ cursor: 'pointer' }} onClick={() => {
+                if (activeQuest) {
+                  const currentStep = activeQuest.steps[currentStepIndex];
+                  if (currentStep.targetType === 'property' && currentStep.targetId === prop.name) {
+                    advanceQuestStep();
+                  }
+                }
+              }}>
                 <div>
                   <span className="property-name">{prop.name}</span>
                   {prop.isIdentifier && <span className="property-identifier">ID</span>}

--- a/src/data/questGenerator.ts
+++ b/src/data/questGenerator.ts
@@ -160,6 +160,7 @@ export function generateQuestsForOntology(ontology: Ontology): Quest[] {
           id: `step-4-${propSteps.length + 1}`,
           instruction: `Find the identifier property '${identifierProp.name}' in ${entity.name}`,
           targetType: 'property',
+          targetId: identifierProp.name,
           hint: `Look for the key icon 🔑 marking the identifier`
         });
       }

--- a/src/data/quests.ts
+++ b/src/data/quests.ts
@@ -185,6 +185,7 @@ export const quests: Quest[] = [
         id: "step-5-2",
         instruction: "Examine how Customer properties map to lakehouse columns",
         targetType: "property",
+        targetId: "name",
         hint: "Notice how 'name' maps to 'full_name' in the source"
       },
       {


### PR DESCRIPTION
- Add missing targetId to step-5-2 in Data Binding Discovery quest
- Add targetId to dynamic property steps in questGenerator
- Add click handler on property items in InspectorPanel to advance quest steps when targetType is 'property' and targetId matches