### PR TITLE
feat: pin ontology fundamentals first in learn catalog

### DIFF
--- a/src/components/LearnPage.test.tsx
+++ b/src/components/LearnPage.test.tsx
@@ -1,0 +1,80 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import { LearnPage } from './LearnPage';
+import type { LearnManifest } from '../types/learn';
+
+const manifestFixture: LearnManifest = {
+  generatedAt: '2026-05-04T00:00:00.000Z',
+  courses: [
+    {
+      slug: 'finance-path',
+      title: 'Finance Path',
+      description: 'Finance learning path',
+      type: 'path',
+      icon: '🏦',
+      articles: [
+        {
+          slug: 'finance-overview',
+          title: 'Finance Overview',
+          description: 'Start here',
+          order: 1,
+          html: '<p>Finance</p>',
+        },
+      ],
+    },
+    {
+      slug: 'ontology-fundamentals',
+      title: 'Ontology Fundamentals',
+      description: 'Foundational concepts',
+      type: 'path',
+      icon: '📘',
+      articles: [
+        {
+          slug: 'what-is-ontology',
+          title: 'What is an ontology?',
+          description: 'Basics',
+          order: 1,
+          html: '<p>Intro</p>',
+        },
+      ],
+    },
+    {
+      slug: 'healthcare-path',
+      title: 'Healthcare Path',
+      description: 'Healthcare learning path',
+      type: 'path',
+      icon: '🏥',
+      articles: [
+        {
+          slug: 'healthcare-overview',
+          title: 'Healthcare Overview',
+          description: 'Start here',
+          order: 1,
+          html: '<p>Healthcare</p>',
+        },
+      ],
+    },
+  ],
+};
+
+describe('LearnPage course ordering', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('pins ontology fundamentals first while preserving order of other courses', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve(manifestFixture),
+    } as Response);
+
+    const { container } = render(<LearnPage route={{ page: 'learn' }} />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Ontology Fundamentals')).toBeInTheDocument();
+    });
+
+    const titles = Array.from(container.querySelectorAll('.learn-card h2')).map((node) => node.textContent?.trim());
+    expect(titles).toEqual(['Ontology Fundamentals', 'Finance Path', 'Healthcare Path']);
+  });
+});

--- a/src/components/LearnPage.tsx
+++ b/src/components/LearnPage.tsx
@@ -107,6 +107,15 @@ export function LearnPage({ route }: LearnPageProps) {
 // -------------------------------------------------------------------
 
 function CourseCatalogue({ courses }: { courses: LearnCourse[] }) {
+  const orderedCourses = useMemo(() => {
+    const pinnedSlug = 'ontology-fundamentals';
+    return [...courses].sort((a, b) => {
+      if (a.slug === pinnedSlug) return -1;
+      if (b.slug === pinnedSlug) return 1;
+      return 0;
+    });
+  }, [courses]);
+
   return (
     <div className="learn-index">
       <div className="learn-index-hero">
@@ -116,7 +125,7 @@ function CourseCatalogue({ courses }: { courses: LearnCourse[] }) {
         </p>
       </div>
       <div className="learn-card-grid">
-        {courses.map((c) => (
+        {orderedCourses.map((c) => (
           <button
             key={c.slug}
             className="learn-card"


### PR DESCRIPTION
This PR pins Ontology Fundamentals as the first card in the Learn catalogue so new users see the foundational path first, while keeping the existing relative order of all other courses unchanged. Verified locally via build and browser check on /#/learn.

<img width="1169" height="917" alt="image" src="https://github.com/user-attachments/assets/e2486fe3-95a0-4adc-a16e-b120b34fbca5" />
