### PR TITLE
feat(fabric): add Push-to-Fabric deploy wizard with workspace picker …

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,5 @@
+# Microsoft Fabric MSAL client ID (optional).
+# Leave empty to disable popup login and use the access-token paste flow only.
+# To enable single sign-on, register a multi-tenant SPA app in Microsoft Entra
+# (see DEPLOYMENT.md for the 5-step guide) and paste its Application (client) ID below.
+VITE_FABRIC_CLIENT_ID=

--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,7 @@ release-review/
 data/codemind*.db
 **/codemind*.db
 .codemind/
+
+# Local secrets
+.env
+

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -1,0 +1,182 @@
+# Ontology Playground — Deployment Guide
+
+Deploy the Ontology Playground as a static web app so your team can design ontologies visually and push them directly to Microsoft Fabric.
+
+---
+
+## Prerequisites
+
+| Requirement | Version |
+|---|---|
+| Node.js | 18+ |
+| npm | 9+ |
+| Microsoft Fabric workspace | With active capacity (F2 or higher, Trial, or PPU) |
+| Microsoft Entra ID tenant | With admin consent capabilities |
+
+---
+
+## Step 1 — Clone & Install
+
+```bash
+git clone <repo-url>
+cd Ontology-Playground
+npm install
+```
+
+Verify the setup:
+
+```bash
+npm test          # should pass all tests
+npm run build     # should produce dist/
+```
+
+---
+
+## Step 2 — Register a Microsoft Entra App
+
+The app uses MSAL to authenticate users against Fabric APIs. Each customer deployment needs its own app registration.
+
+1. Go to **[portal.azure.com](https://portal.azure.com)** → **Microsoft Entra ID** → **App registrations** → **New registration**
+2. Set:
+   - **Name**: `Ontology Playground` (or your preferred name)
+   - **Supported account types**: *Accounts in this organizational directory only* (single-tenant) — or *Accounts in any organizational directory* (multi-tenant) if needed
+   - **Redirect URI**: Select **Single-page application (SPA)** and enter your deployment URL (e.g., `https://ontology.yourcompany.com`)
+3. After registration, go to **API permissions** → **Add a permission** → **APIs my organization uses** → search for `Microsoft Fabric` (or `Power BI Service`)
+4. Add these **delegated** permissions:
+   - `Workspace.ReadWrite.All`
+   - `Item.ReadWrite.All`
+5. Click **Grant admin consent for [your tenant]**
+6. Copy the **Application (client) ID** from the Overview page
+
+> **Tip:** For local development, add `http://localhost:5173` and `http://localhost:4173` as additional redirect URIs.
+
+---
+
+## Step 3 — Configure Environment
+
+Create a `.env` file in the project root:
+
+```env
+# Required — your Entra app registration client ID
+VITE_FABRIC_CLIENT_ID=your-client-id-here
+```
+
+### Optional Environment Variables
+
+| Variable | Description | Default |
+|---|---|---|
+| `VITE_FABRIC_CLIENT_ID` | Entra app client ID for Fabric SSO. Leave empty to disable popup login and use the access-token paste flow only. | _empty_ (token-paste only) |
+| `VITE_ENABLE_AI_BUILDER` | Enable AI-powered ontology builder (`true`/`false`) | `false` |
+| `VITE_GITHUB_CLIENT_ID` | GitHub OAuth app client ID for import/export | Disabled |
+| `VITE_GITHUB_OAUTH_BASE` | GitHub OAuth proxy URL | `/api/github-oauth` |
+| `VITE_ENABLE_LEGACY_FORMATS` | Show legacy export formats (`true`/`false`) | `false` |
+| `VITE_BASE_PATH` | Base path if not hosted at root (e.g., `/playground`) | `/` |
+
+---
+
+## Step 4 — Build
+
+```bash
+npm run build
+```
+
+This produces a `dist/` folder containing the fully static site. No server-side runtime is required.
+
+---
+
+## Step 5 — Deploy
+
+Host the `dist/` folder on any static hosting provider:
+
+### Azure Static Web Apps (Recommended)
+
+```bash
+# Install the SWA CLI
+npm install -g @azure/static-web-apps-cli
+
+# Deploy
+swa deploy ./dist --env production
+```
+
+Or configure a GitHub Actions workflow with the `Azure/static-web-apps-deploy` action.
+
+### Other Options
+
+| Platform | Command / Notes |
+|---|---|
+| **GitHub Pages** | Push `dist/` to a `gh-pages` branch |
+| **Nginx** | Copy `dist/` to your web root; add SPA fallback: `try_files $uri /index.html` |
+| **Azure Blob Storage** | Enable static website hosting, upload `dist/` to `$web` container |
+| **Vercel / Netlify** | Connect repo, set build command to `npm run build`, output dir to `dist` |
+
+> **Important:** The app uses client-side hash routing (`/#/path`), so most hosts work without special rewrite rules. If you switch to browser-history routing in the future, add a fallback to `index.html` for all 404s.
+
+---
+
+## Step 6 — Fabric Workspace Setup
+
+Before users can push ontologies, the target Fabric workspace must meet these requirements:
+
+1. **Fabric capacity assigned** — The workspace must be backed by a Fabric capacity (F2+, Trial, or PPU). Without capacity, pushes fail with `CapacityNotActive`.
+2. **User permissions** — Users need at least **Contributor** role on the workspace to create/update ontology items.
+3. **Capacity must be active** — If using a paused capacity (e.g., dev/test F-SKU), resume it before pushing:
+
+```bash
+# Resume a paused capacity via Azure CLI
+az resource invoke-action \
+  --action resume \
+  --ids "/subscriptions/{sub}/resourceGroups/{rg}/providers/Microsoft.Fabric/capacities/{name}" \
+  --api-version 2023-11-01
+```
+
+---
+
+## Verifying the Deployment
+
+1. Open the deployed URL in a browser
+2. Click **Push** in the header
+3. Sign in with your Microsoft work account
+4. Select a workspace — it should show workspaces with Fabric capacity
+5. Choose **Create new** and push a sample ontology
+
+If you see errors:
+- **"CapacityNotActive"** — Resume or assign a Fabric capacity to the workspace
+- **"InsufficientScopes"** — Ensure admin consent was granted for the API permissions
+- **"AADSTS65001"** — The user hasn't consented; an admin must grant consent in Entra
+
+---
+
+## Architecture Overview
+
+```
+┌──────────────────────────────────┐
+│   Browser (Static SPA)           │
+│   React 19 + TypeScript + Vite   │
+├──────────────────────────────────┤
+│   MSAL.js v5 (auth)             │
+│   ↓ Bearer token                │
+├──────────────────────────────────┤
+│   Fabric REST API                │
+│   POST /ontologies               │
+│   (creates Ontology + Lakehouse  │
+│    + SQL Endpoint + GraphModel)  │
+└──────────────────────────────────┘
+```
+
+- **No backend required** — all API calls go directly from the browser to Fabric REST APIs
+- **Authentication** — MSAL redirect flow; tokens stored in `sessionStorage`
+- **Ontology creation is async** — POST returns 202, the app polls until complete (~60-90s)
+
+---
+
+## Updating
+
+Pull the latest code and rebuild:
+
+```bash
+git pull
+npm install
+npm run build
+```
+
+Re-deploy the updated `dist/` folder to your hosting provider.

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "ontology-quest",
       "version": "0.0.0",
       "dependencies": {
+        "@azure/msal-browser": "^5.6.3",
         "@types/cytoscape": "^3.21.9",
         "@types/sanitize-html": "^2.16.0",
         "cytoscape": "^3.33.1",
@@ -109,6 +110,27 @@
       "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@azure/msal-browser": {
+      "version": "5.6.3",
+      "resolved": "https://registry.npmjs.org/@azure/msal-browser/-/msal-browser-5.6.3.tgz",
+      "integrity": "sha512-sTjMtUm+bJpENU/1WlRzHEsgEHppZDZ1EtNyaOODg/sQBtMxxJzGB+MOCM+T2Q5Qe1fKBrdxUmjyRxm0r7Ez9w==",
+      "license": "MIT",
+      "dependencies": {
+        "@azure/msal-common": "16.4.1"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/@azure/msal-common": {
+      "version": "16.4.1",
+      "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-16.4.1.tgz",
+      "integrity": "sha512-Bl8f+w37xkXsYh7QRkAKCFGYtWMYuOVO7Lv+BxILrvGz3HbIEF22Pt0ugyj0QPOl6NLrHcnNUQ9yeew98P/5iw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.0"
+      }
     },
     "node_modules/@babel/code-frame": {
       "version": "7.28.6",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "validate": "tsx scripts/validate-rdf.ts"
   },
   "dependencies": {
+    "@azure/msal-browser": "^5.6.3",
     "@types/cytoscape": "^3.21.9",
     "@types/sanitize-html": "^2.16.0",
     "cytoscape": "^3.33.1",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -29,8 +29,9 @@ import { useDesignerStore } from './store/designerStore';
 import { useRoute } from './hooks/useRoute';
 import { navigate } from './lib/router';
 import { decodeSharePayload } from './lib/shareCodec';
+import { hasPendingDeployIntent, clearDeployIntent } from './lib/msalAuth';
 import type { Catalogue } from './types/catalogue';
-import { Search, MessageSquare, Info, Compass, LayoutGrid, PenTool, BookOpen, FileJson, HelpCircle, Database, Sun, Moon, FileText } from 'lucide-react';
+import { Search, MessageSquare, Info, Compass, LayoutGrid, PenTool, BookOpen, FileJson, HelpCircle, Database, Sun, Moon, FileText, Rocket } from 'lucide-react';
 import './styles/app.css';
 
 const AI_BUILDER_ENABLED = import.meta.env.VITE_ENABLE_AI_BUILDER === 'true';
@@ -50,6 +51,13 @@ function App() {
   const [showImportExport, setShowImportExport] = useState(false);
   const [showNLBuilder, setShowNLBuilder] = useState(false);
   const [showFabricExport, setShowFabricExport] = useState(false);
+
+  // Auto-open push modal if returning from redirect-based auth
+  useEffect(() => {
+    if (hasPendingDeployIntent()) {
+      setShowFabricExport(true);
+    }
+  }, []);
   const [showSummary, setShowSummary] = useState(false);
   const [toast, setToast] = useState<{ message: string; icon: string } | null>(null);
   const [mobilePanel, setMobilePanel] = useState<'graph' | 'quests' | 'inspector' | 'query'>('graph');
@@ -164,6 +172,7 @@ function App() {
     { id: 'designer', label: 'Open Designer', icon: <PenTool size={18} />, action: openDesigner },
     { id: 'learn', label: 'Open Ontology School', icon: <BookOpen size={18} />, action: openLearn },
     { id: 'import-export', label: 'Import / Export', icon: <FileJson size={18} />, action: () => setShowImportExport(true) },
+    { id: 'deploy-fabric', label: 'Push to Fabric', icon: <Rocket size={18} />, action: () => setShowFabricExport(true) },
     { id: 'summary', label: 'View Summary', icon: <FileText size={18} />, action: () => setShowSummary(true) },
     { id: 'about', label: 'About & Trademark Notice', icon: <Info size={18} />, action: () => setShowAbout(true) },
     { id: 'help', label: 'Help', icon: <HelpCircle size={18} />, shortcut: '?', action: () => setShowHelp(true) },
@@ -191,6 +200,7 @@ function App() {
         onLearnClick={openLearn}
         onNLBuilderClick={AI_BUILDER_ENABLED ? () => setShowNLBuilder(true) : undefined}
         onSummaryClick={() => setShowSummary(true)}
+        onDeployClick={() => setShowFabricExport(true)}
       />
       <QuestPanel />
       <OntologyGraph />
@@ -256,7 +266,7 @@ function App() {
       </AnimatePresence>
 
       <AnimatePresence>
-        {showFabricExport && <FabricExportModal onClose={() => setShowFabricExport(false)} />}
+        {showFabricExport && <FabricExportModal onClose={() => { clearDeployIntent(); setShowFabricExport(false); }} />}
       </AnimatePresence>
 
       <AnimatePresence>

--- a/src/components/FabricDeployModal.tsx
+++ b/src/components/FabricDeployModal.tsx
@@ -1,0 +1,821 @@
+import { useState, useCallback, useEffect } from 'react';
+import { motion, AnimatePresence } from 'framer-motion';
+import {
+  X, Loader2, CheckCircle, AlertCircle, Rocket,
+  Database, BarChart3, Network, FileCode, ChevronRight,
+  LogIn, SkipForward, Plus, FolderOpen,
+} from 'lucide-react';
+import {
+  consumeRedirectResult,
+  signInWithRedirect,
+  clearDeployIntent,
+  isMsalConfigured,
+  type FabricAuthResult,
+} from '../lib/msalAuth';
+import { listWorkspaces, createWorkspace, listCapacities, assignCapacity, type FabricWorkspace, type FabricCapacity } from '../lib/fabricWorkspace';
+import {
+  deployToFabric,
+  type DeployConfig,
+  type DeployStep,
+  type DeployResult,
+} from '../lib/fabricDeployPipeline';
+import type { Ontology } from '../data/ontology';
+import type { Catalogue } from '../types/catalogue';
+
+interface FabricDeployModalProps {
+  onClose: () => void;
+  currentOntology?: Ontology | null;
+}
+
+type WizardStep = 'auth' | 'workspace' | 'select-ontologies' | 'configure' | 'deploying' | 'done';
+
+interface OntologyOption {
+  id: string;
+  name: string;
+  description: string;
+  icon: string;
+  ontology: Ontology | null;
+  selected: boolean;
+}
+
+const STEP_ICONS: Record<string, typeof LogIn> = {
+  authenticate: LogIn,
+  ontology: FileCode,
+  lakehouse: Database,
+  'populate-tables': Database,
+  'semantic-model': BarChart3,
+  'graphql-api': Network,
+};
+
+function StatusIcon({ status }: { status: DeployStep['status'] }) {
+  switch (status) {
+    case 'running': return <Loader2 size={16} className="animate-spin text-blue-400" />;
+    case 'success': return <CheckCircle size={16} className="text-green-400" />;
+    case 'error': return <AlertCircle size={16} className="text-red-400" />;
+    case 'skipped': return <SkipForward size={16} className="text-gray-500" />;
+    default: return <div className="w-4 h-4 rounded-full border border-gray-600" />;
+  }
+}
+
+export function FabricDeployModal({ onClose, currentOntology }: FabricDeployModalProps) {
+  const [catalogue, setCatalogue] = useState<Catalogue | null>(null);
+  const [wizardStep, setWizardStep] = useState<WizardStep>('auth');
+
+  // Auth state
+  const [authResult, setAuthResult] = useState<FabricAuthResult | null>(null);
+  const [authLoading, setAuthLoading] = useState(false);
+
+  // Workspace state
+  const [workspaces, setWorkspaces] = useState<FabricWorkspace[]>([]);
+  const [workspacesLoading, setWorkspacesLoading] = useState(false);
+  const [selectedWorkspace, setSelectedWorkspace] = useState<FabricWorkspace | null>(null);
+  const [showCreateWs, setShowCreateWs] = useState(false);
+  const [newWsName, setNewWsName] = useState('');
+  const [newWsDesc, setNewWsDesc] = useState('');
+  const [creatingWs, setCreatingWs] = useState(false);
+  const [wsFilter, setWsFilter] = useState('');
+  const [capacities, setCapacities] = useState<FabricCapacity[]>([]);
+  const [assigningCapacity, setAssigningCapacity] = useState(false);
+
+  // Deploy state
+  const [deploySteps, setDeploySteps] = useState<DeployStep[]>([]);
+  const [deployResult, setDeployResult] = useState<DeployResult | null>(null);
+  const [error, setError] = useState('');
+
+  // Artifact toggles
+  const [createOntologyFlag, setCreateOntologyFlag] = useState(true);
+  const [createLakehouseFlag, setCreateLakehouseFlag] = useState(true);
+  const [createSemanticModelFlag, setCreateSemanticModelFlag] = useState(true);
+  const [createGraphQLFlag, setCreateGraphQLFlag] = useState(true);
+
+  // Ontology selection
+  const [ontologyOptions, setOntologyOptions] = useState<OntologyOption[]>([]);
+
+  // Fetch catalogue
+  useEffect(() => {
+    fetch(`${import.meta.env.BASE_URL}catalogue.json`)
+      .then(res => res.json())
+      .then((data: Catalogue) => setCatalogue(data))
+      .catch(() => { /* catalogue not available */ });
+  }, []);
+
+  // Check for redirect auth result (e.g. after redirect-based login)
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const result = await consumeRedirectResult();
+        if (result && !cancelled) {
+          setAuthResult(result);
+          clearDeployIntent();
+          setWorkspacesLoading(true);
+          setWizardStep('workspace');
+          try {
+            const [wsList, capList] = await Promise.all([
+              listWorkspaces(result.accessToken),
+              listCapacities(result.accessToken),
+            ]);
+            if (!cancelled) {
+              setWorkspaces(wsList);
+              setCapacities(capList);
+            }
+          } catch (err) {
+            if (!cancelled) setError(err instanceof Error ? err.message : 'Failed to load workspaces');
+          } finally {
+            if (!cancelled) setWorkspacesLoading(false);
+          }
+        }
+      } catch {
+        // No redirect result — normal flow
+      }
+    })();
+    return () => { cancelled = true; };
+  }, []);
+
+  // Build ontology options: current ontology first, then catalogue entries
+  useEffect(() => {
+    const options: OntologyOption[] = [];
+
+    // Always offer the current playground ontology if it has entities
+    if (currentOntology && currentOntology.entityTypes.length > 0) {
+      options.push({
+        id: '_current', name: currentOntology.name || 'Current Ontology',
+        description: currentOntology.description || `${currentOntology.entityTypes.length} entities, ${currentOntology.relationships.length} relationships`,
+        icon: '🎯', ontology: currentOntology, selected: true,
+      });
+    }
+
+    if (catalogue) {
+      const windStep3 = catalogue.entries.find(e => e.id === 'official/windpower-step-3');
+      if (windStep3) {
+        options.push({
+          id: 'windpower', name: 'Wind Power Energy System',
+          description: 'Wind farms, turbines, production, environmental impact, grid connections',
+          icon: '🌬️', ontology: windStep3.ontology, selected: options.length === 0,
+        });
+      }
+
+      const finance = catalogue.entries.find(e => e.id === 'official/finance' || e.id === 'official/finance-step-3');
+      if (finance) {
+        options.push({
+          id: 'finance', name: 'Finance & Banking',
+          description: 'Customers, accounts, transactions, banking relationships',
+          icon: '💰', ontology: finance.ontology, selected: false,
+        });
+      }
+
+      const others = ['official/university', 'official/healthcare', 'official/ecommerce', 'official/manufacturing'];
+      for (const id of others) {
+        const entry = catalogue.entries.find(e => e.id === id) ??
+          catalogue.entries.find(e => e.id === `${id}-step-3`);
+        if (entry && !options.some(o => entry.id.includes(o.id))) {
+          options.push({
+            id: entry.id, name: entry.name, description: entry.description,
+            icon: entry.icon ?? '📦', ontology: entry.ontology, selected: false,
+          });
+        }
+      }
+    }
+
+    setOntologyOptions(options);
+  }, [catalogue, currentOntology]);
+
+  // ─── Auth ────────────────────────────────────────────────────────────────
+
+  const handleSignIn = useCallback(async () => {
+    setAuthLoading(true);
+    setError('');
+    try {
+      // Use redirect-based auth (navigates away, returns after login)
+      await signInWithRedirect();
+      // Page navigates away — this line won't execute
+    } catch (err) {
+      setAuthLoading(false);
+      setError(err instanceof Error ? err.message : 'Sign-in failed');
+    }
+  }, []);
+
+  const handleTokenPaste = useCallback((token: string) => {
+    const cleaned = token.trim();
+    if (!cleaned) return;
+    setError('');
+    setAuthResult({
+      accessToken: cleaned,
+      account: { name: 'Token (manual)', username: '' },
+      expiresOn: null,
+    });
+    setWizardStep('workspace');
+  }, []);
+
+  // ─── Workspace ───────────────────────────────────────────────────────────
+
+  const handleCreateWorkspace = useCallback(async () => {
+    if (!authResult || !newWsName.trim()) return;
+    setCreatingWs(true);
+    setError('');
+    try {
+      const ws = await createWorkspace(authResult.accessToken, newWsName.trim(), newWsDesc.trim());
+      setWorkspaces(prev => [...prev, ws].sort((a, b) => a.displayName.localeCompare(b.displayName)));
+      setSelectedWorkspace(ws);
+      setShowCreateWs(false);
+      setNewWsName('');
+      setNewWsDesc('');
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to create workspace');
+    } finally {
+      setCreatingWs(false);
+    }
+  }, [authResult, newWsName, newWsDesc]);
+
+  // ─── Deploy ──────────────────────────────────────────────────────────────
+
+  const selectedOntologies = ontologyOptions.filter(o => o.selected && o.ontology);
+
+  const toggleOntology = useCallback((id: string) => {
+    setOntologyOptions(prev => prev.map(o =>
+      o.id === id ? { ...o, selected: !o.selected } : o,
+    ));
+  }, []);
+
+  const handleDeploy = useCallback(async () => {
+    if (!authResult || !selectedWorkspace) return;
+    setError('');
+    setWizardStep('deploying');
+
+    const config: DeployConfig = {
+      workspaceId: selectedWorkspace.id,
+      ontologies: selectedOntologies.map(o => o.ontology!),
+      createOntologyItem: createOntologyFlag,
+      createLakehouse: createLakehouseFlag,
+      createSemanticModel: createSemanticModelFlag,
+      createGraphQLApi: createGraphQLFlag,
+      accessToken: authResult.accessToken,
+      accountName: authResult.account.name,
+    };
+
+    try {
+      const result = await deployToFabric(config, setDeploySteps);
+      setDeployResult(result);
+      setWizardStep('done');
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Deployment failed');
+      setWizardStep('done');
+    }
+  }, [authResult, selectedWorkspace, selectedOntologies, createOntologyFlag, createLakehouseFlag, createSemanticModelFlag, createGraphQLFlag]);
+
+  const WIZARD_STEPS: { key: WizardStep; label: string; icon: typeof LogIn }[] = [
+    { key: 'auth', label: 'Sign In', icon: LogIn },
+    { key: 'workspace', label: 'Workspace', icon: FolderOpen },
+    { key: 'select-ontologies', label: 'Ontologies', icon: FileCode },
+    { key: 'configure', label: 'Configure', icon: Database },
+    { key: 'deploying', label: 'Deploy', icon: Rocket },
+    { key: 'done', label: 'Done', icon: CheckCircle },
+  ];
+  const currentStepIdx = WIZARD_STEPS.findIndex(s => s.key === wizardStep);
+
+  const filteredWorkspaces = wsFilter
+    ? workspaces.filter(w => w.displayName.toLowerCase().includes(wsFilter.toLowerCase()))
+    : workspaces;
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm">
+      <motion.div
+        initial={{ opacity: 0, scale: 0.95 }}
+        animate={{ opacity: 1, scale: 1 }}
+        exit={{ opacity: 0, scale: 0.95 }}
+        className="relative w-full max-w-2xl mx-4 rounded-2xl bg-gray-900 border border-gray-700 shadow-2xl overflow-hidden"
+      >
+        {/* Header */}
+        <div className="px-6 py-4 border-b border-gray-700">
+          <div className="flex items-center justify-between mb-3">
+            <div className="flex items-center gap-3">
+              <div className="w-9 h-9 rounded-xl bg-gradient-to-br from-blue-500 to-blue-700 flex items-center justify-center shadow-lg shadow-blue-900/40">
+                <Rocket size={18} className="text-white" />
+              </div>
+              <h2 className="text-lg font-semibold text-white">Deploy to Microsoft Fabric</h2>
+            </div>
+            <button onClick={onClose} className="p-1.5 text-gray-400 hover:text-white rounded-lg hover:bg-gray-800 transition-colors">
+              <X size={18} />
+            </button>
+          </div>
+
+          {/* Step indicator */}
+          <div className="flex items-center gap-1">
+            {WIZARD_STEPS.map((step, i) => {
+              const isComplete = i < currentStepIdx;
+              const isCurrent = i === currentStepIdx;
+              const StepIcon = step.icon;
+              return (
+                <div key={step.key} className="flex items-center flex-1">
+                  <div className="flex flex-col items-center flex-1 min-w-0">
+                    <div className={`w-8 h-8 rounded-full flex items-center justify-center text-xs font-bold transition-all duration-300 ${
+                      isComplete
+                        ? 'bg-green-600 text-white shadow-md shadow-green-900/40'
+                        : isCurrent
+                          ? 'bg-blue-600 text-white shadow-md shadow-blue-900/40 ring-2 ring-blue-400/30'
+                          : 'bg-gray-800 text-gray-500 border border-gray-700'
+                    }`}>
+                      {isComplete ? <CheckCircle size={16} /> : <StepIcon size={14} />}
+                    </div>
+                    <span className={`text-[10px] mt-1 font-medium truncate max-w-full transition-colors ${
+                      isComplete ? 'text-green-400' : isCurrent ? 'text-blue-400' : 'text-gray-600'
+                    }`}>{step.label}</span>
+                  </div>
+                  {i < WIZARD_STEPS.length - 1 && (
+                    <div className={`h-0.5 w-full mx-0.5 rounded transition-colors duration-500 ${
+                      i < currentStepIdx ? 'bg-green-600' : 'bg-gray-800'
+                    }`} />
+                  )}
+                </div>
+              );
+            })}
+          </div>
+        </div>
+
+        {/* Content */}
+        <div className="px-6 py-5 max-h-[70vh] overflow-y-auto">
+          <AnimatePresence mode="wait">
+
+            {/* ─── Step 1: Sign In ─── */}
+            {wizardStep === 'auth' && (
+              <motion.div key="auth" initial={{ opacity: 0, x: 20 }} animate={{ opacity: 1, x: 0 }} exit={{ opacity: 0, x: -20 }}>
+                <div className="text-center py-6">
+                  <div className="w-16 h-16 mx-auto mb-4 rounded-2xl bg-blue-600/20 flex items-center justify-center">
+                    <LogIn size={32} className="text-blue-400" />
+                  </div>
+                  <h3 className="text-lg font-semibold text-white mb-2">Sign in with Microsoft</h3>
+                  <p className="text-gray-400 text-sm mb-6 max-w-md mx-auto">
+                    Sign in with your Microsoft Entra ID account to access your Fabric workspaces and deploy ontology solutions.
+                  </p>
+
+                  {isMsalConfigured() ? (
+                    <button
+                      onClick={handleSignIn}
+                      disabled={authLoading}
+                      className="inline-flex items-center gap-2 px-6 py-3 bg-blue-600 text-white rounded-lg hover:bg-blue-500 text-sm font-medium disabled:opacity-50 disabled:cursor-not-allowed"
+                    >
+                      {authLoading ? (
+                        <><Loader2 size={18} className="animate-spin" /> Redirecting to Microsoft…</>
+                      ) : (
+                        <><LogIn size={18} /> Sign in with Microsoft</>
+                      )}
+                    </button>
+                  ) : (
+                    <div className="max-w-md mx-auto text-left">
+                      <div className="mb-4 p-3 rounded-lg bg-yellow-900/20 border border-yellow-800 text-xs text-yellow-200">
+                        <strong>Popup sign-in is not configured.</strong> Set <code className="font-mono bg-black/30 px-1 rounded">VITE_FABRIC_CLIENT_ID</code> in <code className="font-mono bg-black/30 px-1 rounded">.env</code> to enable single sign-on (see <code className="font-mono bg-black/30 px-1 rounded">DEPLOYMENT.md</code>), or paste a Fabric access token below to continue.
+                      </div>
+                      <label className="block text-xs font-medium text-gray-300 mb-1">Fabric access token</label>
+                      <textarea
+                        rows={4}
+                        placeholder="eyJ0eXAiOiJKV1Qi…"
+                        className="w-full px-3 py-2 text-xs font-mono rounded-lg bg-gray-800 border border-gray-700 text-white placeholder-gray-500 focus:outline-none focus:border-blue-500"
+                        onChange={e => {
+                          const v = e.target.value;
+                          if (v.split('.').length === 3 && v.length > 100) {
+                            handleTokenPaste(v);
+                          }
+                        }}
+                      />
+                      <p className="mt-2 text-[11px] text-gray-500">
+                        Get a token from <code className="font-mono">az account get-access-token --resource https://api.fabric.microsoft.com</code>
+                      </p>
+                    </div>
+                  )}
+
+                  {error && <p className="mt-4 text-sm text-red-400 max-w-md mx-auto">{error}</p>}
+                </div>
+              </motion.div>
+            )}
+
+            {/* ─── Step 2: Pick Workspace ─── */}
+            {wizardStep === 'workspace' && (
+              <motion.div key="workspace" initial={{ opacity: 0, x: 20 }} animate={{ opacity: 1, x: 0 }} exit={{ opacity: 0, x: -20 }}>
+                {authResult && (
+                  <div className="mb-4 p-3 rounded-lg bg-green-900/20 border border-green-800 flex items-center gap-2">
+                    <CheckCircle size={16} className="text-green-400" />
+                    <span className="text-sm text-green-300">Signed in as <strong>{authResult.account.name}</strong> ({authResult.account.username})</span>
+                  </div>
+                )}
+
+                <div className="flex items-center justify-between mb-3">
+                  <p className="text-gray-400 text-sm">Select a workspace or create a new one:</p>
+                  <button
+                    onClick={() => setShowCreateWs(!showCreateWs)}
+                    className="flex items-center gap-1 px-3 py-1.5 text-xs font-medium text-blue-400 border border-blue-600 rounded-lg hover:bg-blue-900/30"
+                  >
+                    <Plus size={14} /> New Workspace
+                  </button>
+                </div>
+
+                {/* Create workspace form */}
+                {showCreateWs && (
+                  <div className="mb-4 p-4 rounded-lg bg-gray-800 border border-gray-600">
+                    <label className="block text-xs font-medium text-gray-400 mb-1">Workspace Name</label>
+                    <input
+                      type="text"
+                      value={newWsName}
+                      onChange={e => setNewWsName(e.target.value)}
+                      placeholder="My Ontology Workspace"
+                      className="w-full px-3 py-2 mb-2 rounded-lg bg-gray-700 border border-gray-600 text-white text-sm placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-blue-500"
+                    />
+                    <label className="block text-xs font-medium text-gray-400 mb-1">Description (optional)</label>
+                    <input
+                      type="text"
+                      value={newWsDesc}
+                      onChange={e => setNewWsDesc(e.target.value)}
+                      placeholder="Workspace for ontology solutions"
+                      className="w-full px-3 py-2 mb-3 rounded-lg bg-gray-700 border border-gray-600 text-white text-sm placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-blue-500"
+                    />
+                    <div className="flex gap-2">
+                      <button
+                        onClick={handleCreateWorkspace}
+                        disabled={!newWsName.trim() || creatingWs}
+                        className="flex items-center gap-1 px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-500 text-xs font-medium disabled:opacity-50"
+                      >
+                        {creatingWs ? <><Loader2 size={14} className="animate-spin" /> Creating…</> : <><Plus size={14} /> Create</>}
+                      </button>
+                      <button onClick={() => setShowCreateWs(false)} className="px-3 py-2 text-gray-400 text-xs hover:text-white">Cancel</button>
+                    </div>
+                  </div>
+                )}
+
+                {/* Search filter */}
+                {workspaces.length > 5 && (
+                  <input
+                    type="text"
+                    value={wsFilter}
+                    onChange={e => setWsFilter(e.target.value)}
+                    placeholder="Search workspaces…"
+                    className="w-full px-3 py-2 mb-3 rounded-lg bg-gray-800 border border-gray-600 text-white text-sm placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-blue-500"
+                  />
+                )}
+
+                {/* Workspace list */}
+                {workspacesLoading ? (
+                  <div className="flex items-center justify-center py-8 gap-2 text-gray-400">
+                    <Loader2 size={18} className="animate-spin" /> Loading workspaces…
+                  </div>
+                ) : filteredWorkspaces.length === 0 ? (
+                  <div className="text-center py-8 text-gray-500 text-sm">
+                    {workspaces.length === 0 ? 'No workspaces found. Create a new one above.' : 'No workspaces match your search.'}
+                  </div>
+                ) : (
+                  <div className="space-y-1 max-h-64 overflow-y-auto">
+                    {filteredWorkspaces.map(ws => (
+                      <button
+                        key={ws.id}
+                        onClick={() => setSelectedWorkspace(ws)}
+                        className={`w-full flex items-center gap-3 p-3 rounded-lg border text-left transition-colors ${
+                          selectedWorkspace?.id === ws.id
+                            ? 'bg-blue-900/30 border-blue-600 text-white'
+                            : 'bg-gray-800/30 border-gray-700 text-gray-300 hover:border-gray-500 hover:text-white'
+                        }`}
+                      >
+                        <FolderOpen size={18} className={selectedWorkspace?.id === ws.id ? 'text-blue-400' : 'text-gray-500'} />
+                        <div className="flex-1 min-w-0">
+                          <div className="text-sm font-medium truncate flex items-center gap-2">
+                            {ws.displayName}
+                            {ws.capacityId ? (
+                              <span className="inline-flex items-center px-1.5 py-0.5 text-[10px] font-medium rounded bg-green-900/40 text-green-400 border border-green-800">✓ Capacity</span>
+                            ) : (
+                              <span className="inline-flex items-center px-1.5 py-0.5 text-[10px] font-medium rounded bg-amber-900/40 text-amber-400 border border-amber-800">No capacity</span>
+                            )}
+                          </div>
+                          {ws.description && <div className="text-xs text-gray-500 truncate">{ws.description}</div>}
+                        </div>
+                        {selectedWorkspace?.id === ws.id && <CheckCircle size={16} className="text-blue-400 flex-shrink-0" />}
+                      </button>
+                    ))}
+                  </div>
+                )}
+
+                {/* Warning + assign capacity for workspaces without capacity */}
+                {selectedWorkspace && !selectedWorkspace.capacityId && (
+                  <div className="mt-3 p-3 rounded-lg bg-amber-900/20 border border-amber-800">
+                    <p className="text-sm text-amber-300 mb-2">
+                      ⚠️ <strong>{selectedWorkspace.displayName}</strong> has no Fabric capacity assigned. Deploying artifacts requires a capacity.
+                    </p>
+                    {capacities.length > 0 ? (
+                      <div className="flex items-center gap-2">
+                        <select
+                          id="capacity-select"
+                          className="flex-1 px-2 py-1.5 rounded bg-gray-800 border border-gray-600 text-white text-xs"
+                          defaultValue={capacities[0]?.id}
+                        >
+                          {capacities.map(c => (
+                            <option key={c.id} value={c.id}>{c.displayName} ({c.sku} — {c.region})</option>
+                          ))}
+                        </select>
+                        <button
+                          onClick={async () => {
+                            if (!authResult) return;
+                            const select = document.getElementById('capacity-select') as HTMLSelectElement;
+                            setAssigningCapacity(true);
+                            setError('');
+                            try {
+                              await assignCapacity(authResult.accessToken, selectedWorkspace.id, select.value);
+                              setSelectedWorkspace({ ...selectedWorkspace, capacityId: select.value });
+                              setWorkspaces(prev => prev.map(w => w.id === selectedWorkspace.id ? { ...w, capacityId: select.value } : w));
+                            } catch (err) {
+                              setError(err instanceof Error ? err.message : 'Failed to assign capacity');
+                            } finally {
+                              setAssigningCapacity(false);
+                            }
+                          }}
+                          disabled={assigningCapacity}
+                          className="px-3 py-1.5 bg-amber-600 text-white rounded text-xs font-medium hover:bg-amber-500 disabled:opacity-50"
+                        >
+                          {assigningCapacity ? 'Assigning…' : 'Assign'}
+                        </button>
+                      </div>
+                    ) : (
+                      <p className="text-xs text-gray-400">No available capacities found. Assign a capacity in the Fabric admin portal.</p>
+                    )}
+                  </div>
+                )}
+
+                {error && <p className="mt-2 text-sm text-red-400">{error}</p>}
+
+                <div className="flex justify-end mt-4">
+                  <button
+                    onClick={() => { setError(''); setWizardStep('select-ontologies'); }}
+                    disabled={!selectedWorkspace || !selectedWorkspace.capacityId}
+                    className="flex items-center gap-2 px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-500 text-sm font-medium disabled:opacity-50 disabled:cursor-not-allowed"
+                  >
+                    Next <ChevronRight size={16} />
+                  </button>
+                </div>
+              </motion.div>
+            )}
+
+            {/* ─── Step 3: Select Ontologies ─── */}
+            {wizardStep === 'select-ontologies' && (
+              <motion.div key="select" initial={{ opacity: 0, x: 20 }} animate={{ opacity: 1, x: 0 }} exit={{ opacity: 0, x: -20 }}>
+                <p className="text-gray-400 text-sm mb-4">
+                  Select ontologies to deploy to <strong className="text-white">{selectedWorkspace?.displayName}</strong>:
+                </p>
+                <div className="space-y-2">
+                  {ontologyOptions.map(opt => (
+                    <button
+                      key={opt.id}
+                      onClick={() => toggleOntology(opt.id)}
+                      className={`w-full flex items-center gap-3 p-3 rounded-lg border text-left transition-colors ${
+                        opt.selected
+                          ? 'bg-blue-900/30 border-blue-600 text-white'
+                          : 'bg-gray-800/50 border-gray-700 text-gray-400 hover:border-gray-500'
+                      }`}
+                    >
+                      <span className="text-2xl">{opt.icon}</span>
+                      <div className="flex-1 min-w-0">
+                        <div className="font-medium text-sm">{opt.name}</div>
+                        <div className="text-xs text-gray-500 truncate">{opt.description}</div>
+                      </div>
+                      <div className={`w-5 h-5 rounded border-2 flex items-center justify-center flex-shrink-0 ${
+                        opt.selected ? 'bg-blue-600 border-blue-600' : 'border-gray-600'
+                      }`}>
+                        {opt.selected && <CheckCircle size={14} className="text-white" />}
+                      </div>
+                    </button>
+                  ))}
+                </div>
+                {selectedOntologies.length === 0 && (
+                  <p className="mt-2 text-sm text-amber-400">Select at least one ontology</p>
+                )}
+                <div className="flex justify-between mt-6">
+                  <button onClick={() => setWizardStep('workspace')} className="px-4 py-2 text-gray-400 hover:text-white text-sm transition-colors">← Back</button>
+                  <button
+                    onClick={() => setWizardStep('configure')}
+                    disabled={selectedOntologies.length === 0}
+                    className="flex items-center gap-2 px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-500 text-sm font-medium disabled:opacity-50 disabled:cursor-not-allowed"
+                  >
+                    Next <ChevronRight size={16} />
+                  </button>
+                </div>
+              </motion.div>
+            )}
+
+            {/* ─── Step 4: Configure ─── */}
+            {wizardStep === 'configure' && (
+              <motion.div key="configure" initial={{ opacity: 0, x: 20 }} animate={{ opacity: 1, x: 0 }} exit={{ opacity: 0, x: -20 }}>
+                <p className="text-gray-400 text-sm mb-4">Choose which Fabric artifacts to create:</p>
+                <div className="space-y-3">
+                  {[
+                    { label: 'Fabric IQ Ontology', desc: 'Ontology definition with entities and relationships', icon: FileCode, checked: createOntologyFlag, onChange: setCreateOntologyFlag },
+                    { label: 'Lakehouse + Data Tables', desc: 'Delta tables populated with sample data', icon: Database, checked: createLakehouseFlag, onChange: setCreateLakehouseFlag },
+                    { label: 'Power BI Semantic Model', desc: 'Tabular model with relationships (DirectLake)', icon: BarChart3, checked: createSemanticModelFlag, onChange: setCreateSemanticModelFlag },
+                    { label: 'GraphQL API', desc: 'GraphQL endpoint backed by Lakehouse tables', icon: Network, checked: createGraphQLFlag, onChange: setCreateGraphQLFlag },
+                  ].map(item => (
+                    <label key={item.label} className={`flex items-center gap-3 p-3 rounded-lg border cursor-pointer transition-all ${
+                      item.checked
+                        ? 'bg-blue-900/20 border-blue-800 hover:border-blue-600'
+                        : 'bg-gray-800/50 border-gray-700 hover:border-gray-500 opacity-60'
+                    }`}>
+                      <input
+                        type="checkbox"
+                        checked={item.checked}
+                        onChange={e => item.onChange(e.target.checked)}
+                        className="w-4 h-4 rounded border-gray-600 text-blue-600 focus:ring-blue-500 bg-gray-700"
+                      />
+                      <item.icon size={18} className={item.checked ? 'text-blue-400' : 'text-gray-500'} />
+                      <div>
+                        <div className="text-sm font-medium text-white">{item.label}</div>
+                        <div className="text-xs text-gray-500">{item.desc}</div>
+                      </div>
+                    </label>
+                  ))}
+                </div>
+
+                {/* Deploy summary card */}
+                <div className="mt-5 p-4 rounded-xl bg-gradient-to-br from-gray-800 to-gray-800/60 border border-gray-700">
+                  <div className="text-xs text-gray-400 mb-2 font-medium uppercase tracking-wider">Deploy Summary</div>
+                  <div className="flex items-center gap-3 mb-2">
+                    <div className="text-2xl">{selectedOntologies[0]?.icon ?? '📦'}</div>
+                    <div>
+                      <div className="text-sm text-white font-medium">
+                        {selectedOntologies.length} ontolog{selectedOntologies.length > 1 ? 'ies' : 'y'}
+                      </div>
+                      <div className="text-xs text-gray-500">
+                        {selectedOntologies.map(o => o.name).join(', ')}
+                      </div>
+                    </div>
+                    <ChevronRight size={16} className="text-gray-600 mx-1" />
+                    <div className="flex items-center gap-2">
+                      <FolderOpen size={16} className="text-blue-400" />
+                      <div className="text-sm text-blue-400 font-medium">{selectedWorkspace?.displayName}</div>
+                    </div>
+                  </div>
+                  <div className="text-xs text-gray-500">
+                    {[createOntologyFlag && 'Ontology', createLakehouseFlag && 'Lakehouse', createSemanticModelFlag && 'Semantic Model', createGraphQLFlag && 'GraphQL API'].filter(Boolean).join(' · ')}
+                  </div>
+                </div>
+
+                {error && <p className="mt-2 text-sm text-red-400">{error}</p>}
+
+                <div className="flex justify-between mt-6">
+                  <button onClick={() => setWizardStep('select-ontologies')} className="px-4 py-2 text-gray-400 hover:text-white text-sm transition-colors">← Back</button>
+                  <button
+                    onClick={handleDeploy}
+                    className="flex items-center gap-2 px-6 py-3 bg-gradient-to-r from-green-600 to-green-500 text-white rounded-xl hover:from-green-500 hover:to-green-400 text-sm font-semibold shadow-lg shadow-green-900/40 transition-all active:scale-95"
+                  >
+                    <Rocket size={18} /> Deploy to Fabric
+                  </button>
+                </div>
+              </motion.div>
+            )}
+
+            {/* ─── Step 5: Deploying ─── */}
+            {wizardStep === 'deploying' && (
+              <motion.div key="deploying" initial={{ opacity: 0 }} animate={{ opacity: 1 }}>
+                <div className="flex items-center gap-3 mb-4">
+                  <div className="w-10 h-10 rounded-xl bg-blue-600/20 flex items-center justify-center">
+                    <Loader2 size={20} className="animate-spin text-blue-400" />
+                  </div>
+                  <div>
+                    <p className="text-white font-medium text-sm">Deploying to <strong>{selectedWorkspace?.displayName}</strong></p>
+                    <p className="text-gray-500 text-xs">
+                      {deploySteps.filter(s => s.status === 'success').length} of {deploySteps.length} steps complete
+                    </p>
+                  </div>
+                </div>
+
+                {/* Progress bar */}
+                <div className="w-full h-2 bg-gray-800 rounded-full mb-4 overflow-hidden">
+                  <motion.div
+                    className="h-full bg-gradient-to-r from-blue-600 to-blue-400 rounded-full"
+                    initial={{ width: '0%' }}
+                    animate={{ width: `${Math.max(5, (deploySteps.filter(s => s.status === 'success').length / deploySteps.length) * 100)}%` }}
+                    transition={{ duration: 0.5, ease: 'easeOut' }}
+                  />
+                </div>
+
+                <div className="space-y-2">
+                  {deploySteps.map((step, i) => {
+                    const Icon = STEP_ICONS[step.id] ?? FileCode;
+                    return (
+                      <motion.div
+                        key={step.id}
+                        initial={{ opacity: 0, y: 8 }}
+                        animate={{ opacity: 1, y: 0 }}
+                        transition={{ delay: i * 0.05 }}
+                        className={`flex items-center gap-3 p-3 rounded-lg border transition-colors ${
+                          step.status === 'running'
+                            ? 'bg-blue-900/20 border-blue-800'
+                            : step.status === 'success'
+                              ? 'bg-green-900/10 border-green-900/30'
+                              : step.status === 'error'
+                                ? 'bg-red-900/10 border-red-900/30'
+                                : 'bg-gray-800/50 border-gray-700'
+                        }`}
+                      >
+                        <StatusIcon status={step.status} />
+                        <Icon size={16} className={step.status === 'success' ? 'text-green-400' : step.status === 'running' ? 'text-blue-400' : 'text-gray-500'} />
+                        <div className="flex-1 min-w-0">
+                          <div className={`text-sm ${step.status === 'success' ? 'text-green-300' : step.status === 'running' ? 'text-white font-medium' : 'text-gray-400'}`}>{step.label}</div>
+                          {step.resultName && <div className="text-xs text-green-400 mt-0.5">✓ {step.resultName}</div>}
+                          {step.error && step.status === 'error' && <div className="text-xs text-red-400 mt-0.5">✗ {step.error}</div>}
+                        </div>
+                      </motion.div>
+                    );
+                  })}
+                </div>
+              </motion.div>
+            )}
+
+            {/* ─── Step 6: Done ─── */}
+            {wizardStep === 'done' && (
+              <motion.div key="done" initial={{ opacity: 0, scale: 0.95 }} animate={{ opacity: 1, scale: 1 }}>
+                {deployResult && (
+                  <>
+                    <div className="text-center py-2 mb-4">
+                      {deployResult.steps.every(s => s.status === 'success') ? (
+                        <motion.div initial={{ scale: 0 }} animate={{ scale: 1 }} transition={{ type: 'spring', damping: 10, stiffness: 150 }}>
+                          <div className="w-20 h-20 mx-auto mb-3 rounded-full bg-green-600/20 flex items-center justify-center ring-4 ring-green-600/10">
+                            <CheckCircle size={40} className="text-green-400" />
+                          </div>
+                          <h3 className="text-xl font-bold text-white">Deployment Complete! 🎉</h3>
+                          <p className="text-sm text-gray-400 mt-1">
+                            All artifacts deployed to <strong className="text-green-400">{selectedWorkspace?.displayName}</strong>
+                          </p>
+                        </motion.div>
+                      ) : (
+                        <>
+                          <div className="w-20 h-20 mx-auto mb-3 rounded-full bg-amber-600/20 flex items-center justify-center">
+                            <AlertCircle size={40} className="text-amber-400" />
+                          </div>
+                          <h3 className="text-xl font-bold text-white">Completed with Issues</h3>
+                          <p className="text-sm text-gray-400 mt-1">Some steps failed — check details below</p>
+                        </>
+                      )}
+                    </div>
+
+                    {/* Results summary */}
+                    <div className="space-y-2 mb-4">
+                      {deployResult.steps.map((step, i) => {
+                        const Icon = STEP_ICONS[step.id] ?? FileCode;
+                        return (
+                          <motion.div
+                            key={step.id}
+                            initial={{ opacity: 0, x: -10 }}
+                            animate={{ opacity: 1, x: 0 }}
+                            transition={{ delay: i * 0.08 }}
+                            className={`flex items-center gap-3 p-3 rounded-lg border ${
+                              step.status === 'success'
+                                ? 'bg-green-900/10 border-green-900/30'
+                                : step.status === 'error'
+                                  ? 'bg-red-900/10 border-red-900/30'
+                                  : 'bg-gray-800/30 border-gray-700'
+                            }`}
+                          >
+                            <StatusIcon status={step.status} />
+                            <Icon size={16} className={step.status === 'success' ? 'text-green-400' : 'text-gray-500'} />
+                            <div className="flex-1 min-w-0">
+                              <div className="text-sm text-white">{step.label}</div>
+                              {step.resultName && <div className="text-xs text-green-400">✓ {step.resultName}</div>}
+                              {step.error && step.status === 'error' && <div className="text-xs text-red-400">✗ {step.error}</div>}
+                            </div>
+                          </motion.div>
+                        );
+                      })}
+                    </div>
+
+                    {selectedWorkspace && (
+                      <a
+                        href={`https://app.fabric.microsoft.com/groups/${selectedWorkspace.id}`}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="flex items-center justify-center gap-2 w-full py-3 rounded-lg bg-blue-600/20 border border-blue-700 text-blue-400 hover:bg-blue-600/30 hover:text-blue-300 text-sm font-medium transition-colors mb-2"
+                      >
+                        <Rocket size={16} /> Open workspace in Fabric →
+                      </a>
+                    )}
+                  </>
+                )}
+
+                {error && !deployResult && (
+                  <div className="text-center py-4">
+                    <div className="w-20 h-20 mx-auto mb-3 rounded-full bg-red-600/20 flex items-center justify-center">
+                      <AlertCircle size={40} className="text-red-400" />
+                    </div>
+                    <h3 className="text-lg font-semibold text-white mb-1">Deployment Failed</h3>
+                    <p className="text-sm text-red-400 max-w-md mx-auto">{error}</p>
+                  </div>
+                )}
+
+                <div className="flex justify-center mt-4">
+                  <button
+                    onClick={onClose}
+                    className="px-8 py-2.5 bg-gray-700 text-white rounded-lg hover:bg-gray-600 text-sm font-medium transition-colors"
+                  >
+                    Close
+                  </button>
+                </div>
+              </motion.div>
+            )}
+
+          </AnimatePresence>
+        </div>
+      </motion.div>
+    </div>
+  );
+}

--- a/src/components/FabricExportModal.tsx
+++ b/src/components/FabricExportModal.tsx
@@ -1,97 +1,242 @@
-import { useState, useCallback } from 'react';
+import { useState, useCallback, useEffect } from 'react';
 import { motion } from 'framer-motion';
-import { X, Cloud, Loader2, CheckCircle, AlertCircle, RefreshCw } from 'lucide-react';
+import { X, Cloud, Loader2, CheckCircle, AlertCircle, RefreshCw, LogIn, FolderOpen, Database, Bot } from 'lucide-react';
 import { useAppStore } from '../store/appStore';
 import {
   createOntology,
+  createOntologyWithData,
   updateOntologyDefinition,
   listOntologies,
+  convertToFabricParts,
+  sanitizeItemName,
   FabricApiError,
+  FabricValidationError,
   type FabricOntologyResponse,
+  type PollProgress,
 } from '../lib/fabric';
+import { generateSampleData } from '../lib/sampleDataGenerator';
+import { consumeRedirectResult, signInWithRedirect, acquireFabricToken, acquireOneLakeToken, getSignedInAccount, type FabricAuthResult } from '../lib/msalAuth';
+import { listWorkspaces, type FabricWorkspace } from '../lib/fabricWorkspace';
 
 interface FabricExportModalProps {
   onClose: () => void;
 }
 
-type Step = 'credentials' | 'workspace' | 'pushing' | 'done' | 'error';
+type Step = 'auth' | 'workspace' | 'pushing' | 'done' | 'error';
 
 export function FabricExportModal({ onClose }: FabricExportModalProps) {
   const { currentOntology } = useAppStore();
 
-  const [step, setStep] = useState<Step>('credentials');
+  const [step, setStep] = useState<Step>('auth');
   const [token, setToken] = useState('');
-  const [workspaceId, setWorkspaceId] = useState('');
+  const [authResult, setAuthResult] = useState<FabricAuthResult | null>(null);
+  const [authLoading, setAuthLoading] = useState(false);
+
+  // Workspace state
+  const [workspaces, setWorkspaces] = useState<FabricWorkspace[]>([]);
+  const [workspacesLoading, setWorkspacesLoading] = useState(false);
+  const [selectedWorkspace, setSelectedWorkspace] = useState<FabricWorkspace | null>(null);
+
   const [existingOntologies, setExistingOntologies] = useState<FabricOntologyResponse[]>([]);
   const [selectedOntologyId, setSelectedOntologyId] = useState<string | ''>('');
   const [mode, setMode] = useState<'create' | 'update'>('create');
   const [error, setError] = useState('');
   const [result, setResult] = useState<FabricOntologyResponse | null>(null);
-  const [loading, setLoading] = useState(false);
+  const [ontologiesLoading, setOntologiesLoading] = useState(false);
+  const [pollProgress, setPollProgress] = useState<PollProgress | null>(null);
+  const [includeSampleData, setIncludeSampleData] = useState(true);
+  const [includeDataAgent, setIncludeDataAgent] = useState(true);
+  const [statusMessage, setStatusMessage] = useState('');
 
-  const handleLoadWorkspace = useCallback(async () => {
-    if (!token.trim() || !workspaceId.trim()) {
-      setError('Both token and workspace ID are required.');
-      return;
-    }
+  // Try to get token silently on mount (user may already be signed in)
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        // Check for redirect result first
+        const redirectResult = await consumeRedirectResult();
+        if (redirectResult && !cancelled) {
+          setAuthResult(redirectResult);
+          setToken(redirectResult.accessToken);
+          // Auto-advance to workspace step
+          setWorkspacesLoading(true);
+          setStep('workspace');
+          try {
+            const wsList = await listWorkspaces(redirectResult.accessToken);
+            if (!cancelled) setWorkspaces(wsList.filter(w => w.capacityId));
+          } catch (err) {
+            if (!cancelled) setError(err instanceof Error ? err.message : 'Failed to load workspaces');
+          } finally {
+            if (!cancelled) setWorkspacesLoading(false);
+          }
+          return;
+        }
 
-    // Basic UUID format validation
-    const uuidRegex = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
-    if (!uuidRegex.test(workspaceId.trim())) {
-      setError('Workspace ID must be a valid UUID (e.g., cfafbeb1-8037-4d0c-896e-a46fb27ff229).');
-      return;
-    }
+        // Try silent token acquisition
+        const existing = await getSignedInAccount();
+        if (existing) {
+          setAuthLoading(true);
+          const tokenResult = await acquireFabricToken();
+          if (!cancelled) {
+            setAuthResult(tokenResult);
+            setToken(tokenResult.accessToken);
+            // Auto-advance
+            setWorkspacesLoading(true);
+            setStep('workspace');
+            try {
+              const wsList = await listWorkspaces(tokenResult.accessToken);
+              if (!cancelled) setWorkspaces(wsList.filter(w => w.capacityId));
+            } catch (err) {
+              if (!cancelled) setError(err instanceof Error ? err.message : 'Failed to load workspaces');
+            } finally {
+              if (!cancelled) setWorkspacesLoading(false);
+            }
+          }
+        }
+      } catch {
+        // Silent token failed — user needs to sign in
+      } finally {
+        if (!cancelled) setAuthLoading(false);
+      }
+    })();
+    return () => { cancelled = true; };
+  }, []);
 
-    setLoading(true);
+  const handleSignIn = useCallback(async () => {
+    setAuthLoading(true);
     setError('');
-
     try {
-      const ontologies = await listOntologies(workspaceId.trim(), token.trim());
-      setExistingOntologies(ontologies);
-      setStep('workspace');
+      await signInWithRedirect();
     } catch (err) {
-      if (err instanceof FabricApiError) {
-        setError(`API error (${err.status}): ${err.message}`);
+      setAuthLoading(false);
+      setError(err instanceof Error ? err.message : 'Sign-in failed');
+    }
+  }, []);
+
+  const handleSelectWorkspace = useCallback(async (ws: FabricWorkspace) => {
+    setSelectedWorkspace(ws);
+    setOntologiesLoading(true);
+    setError('');
+    try {
+      const onts = await listOntologies(ws.id, token);
+      setExistingOntologies(onts);
+    } catch (err) {
+      if (err instanceof FabricApiError && err.status === 403) {
+        setExistingOntologies([]);
       } else {
-        setError(err instanceof Error ? err.message : 'Failed to connect to workspace');
+        setError(err instanceof Error ? err.message : 'Failed to list ontologies');
       }
     } finally {
-      setLoading(false);
+      setOntologiesLoading(false);
     }
-  }, [token, workspaceId]);
+  }, [token]);
 
   const handlePush = useCallback(async () => {
+    if (!selectedWorkspace) return;
     setStep('pushing');
     setError('');
+    setPollProgress(null);
+    setStatusMessage('');
+
+    const onProgress = (progress: PollProgress) => setPollProgress(progress);
 
     try {
-      if (mode === 'create') {
-        const created = await createOntology(
-          workspaceId.trim(),
-          token.trim(),
+      // Refresh token right before push to avoid stale tokens
+      let freshToken = token;
+      try {
+        const refreshed = await acquireFabricToken();
+        freshToken = refreshed.accessToken;
+        setToken(freshToken);
+      } catch (authErr) {
+        console.warn('Token refresh failed, using cached token:', authErr);
+      }
+
+      if (mode === 'create' && includeSampleData) {
+        // Full push with sample data + data bindings
+        setStatusMessage('Generating sample data…');
+        const sampleData = generateSampleData(currentOntology);
+
+        let oneLakeToken: string;
+        try {
+          const olResult = await acquireOneLakeToken();
+          oneLakeToken = olResult.accessToken;
+        } catch (authErr) {
+          // OneLake consent not granted — fall back to creating ontology without data
+          console.warn('OneLake token acquisition failed:', authErr);
+          setStatusMessage('⚠ OneLake permission not granted — creating ontology without sample data. Sign out & sign back in to fix.');
+          const created = await createOntology(
+            selectedWorkspace.id,
+            freshToken,
+            currentOntology,
+            onProgress,
+          );
+          setResult(created);
+          setStep('done');
+          return;
+        }
+
+        const created = await createOntologyWithData(
+          selectedWorkspace.id,
+          freshToken,
+          oneLakeToken,
           currentOntology,
+          sampleData.tables,
+          onProgress,
+          (msg) => setStatusMessage(msg),
+          { includeDataAgent: includeDataAgent },
+        );
+        setResult(created);
+      } else if (mode === 'create') {
+        const created = await createOntology(
+          selectedWorkspace.id,
+          freshToken,
+          currentOntology,
+          onProgress,
         );
         setResult(created);
       } else {
         await updateOntologyDefinition(
-          workspaceId.trim(),
+          selectedWorkspace.id,
           selectedOntologyId,
-          token.trim(),
+          freshToken,
           currentOntology,
+          onProgress,
         );
         const existing = existingOntologies.find(o => o.id === selectedOntologyId);
         setResult(existing ?? null);
       }
       setStep('done');
     } catch (err) {
-      if (err instanceof FabricApiError) {
+      if (err instanceof FabricValidationError) {
+        setError(`Validation error: ${err.message}`);
+      } else if (err instanceof FabricApiError) {
         setError(`API error (${err.status}): ${err.message}`);
       } else {
         setError(err instanceof Error ? err.message : 'Push failed');
       }
       setStep('error');
     }
-  }, [mode, workspaceId, token, currentOntology, selectedOntologyId, existingOntologies]);
+  }, [mode, selectedWorkspace, token, currentOntology, selectedOntologyId, existingOntologies, includeSampleData, includeDataAgent]);
+
+  const handleCopyDebug = useCallback(() => {
+    // Copy the exact POST body that would be sent to Fabric
+    const { definition } = convertToFabricParts(currentOntology);
+    const postBody = {
+      displayName: sanitizeItemName(currentOntology.name),
+      description: (currentOntology.description ?? '').slice(0, 256),
+      definition,
+    };
+    const debugInfo = {
+      postBody: JSON.parse(JSON.stringify(postBody)),
+      decodedParts: definition.parts.map(p => ({
+        path: p.path,
+        decoded: JSON.parse(atob(p.payload)),
+      })),
+      workspace: selectedWorkspace?.id,
+      error,
+    };
+    navigator.clipboard.writeText(JSON.stringify(debugInfo, null, 2));
+  }, [currentOntology, selectedWorkspace, error]);
 
   return (
     <motion.div
@@ -114,7 +259,7 @@ export function FabricExportModal({ onClose }: FabricExportModalProps) {
           <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
             <div style={{
               width: 36, height: 36,
-              background: 'rgba(0, 120, 212, 0.15)',
+              background: 'rgba(0, 102, 179, 0.15)',
               borderRadius: 'var(--radius-md)',
               display: 'flex', alignItems: 'center', justifyContent: 'center',
             }}>
@@ -159,154 +304,223 @@ export function FabricExportModal({ onClose }: FabricExportModalProps) {
           </div>
         )}
 
-        {/* Step: Credentials */}
-        {step === 'credentials' && (
-          <div>
-            <div style={{ marginBottom: 16 }}>
-              <label style={{ display: 'block', fontSize: 13, fontWeight: 600, marginBottom: 6 }}>
-                Workspace ID
-              </label>
-              <input
-                type="text"
-                value={workspaceId}
-                onChange={(e) => setWorkspaceId(e.target.value)}
-                placeholder="00000000-0000-0000-0000-000000000000"
-                spellCheck={false}
-                style={{
-                  width: '100%', padding: '8px 12px',
-                  borderRadius: 'var(--radius-sm)',
-                  border: '1px solid var(--border-primary)',
-                  background: 'var(--bg-secondary)',
-                  color: 'var(--text-primary)',
-                  fontSize: 13, fontFamily: 'var(--font-mono)',
-                  boxSizing: 'border-box',
-                }}
-              />
-              <p style={{ fontSize: 11, color: 'var(--text-tertiary)', marginTop: 4 }}>
-                Find this in Fabric portal → Workspace settings → Overview
-              </p>
-            </div>
-
-            <div style={{ marginBottom: 20 }}>
-              <label style={{ display: 'block', fontSize: 13, fontWeight: 600, marginBottom: 6 }}>
-                Access Token
-              </label>
-              <input
-                type="password"
-                value={token}
-                onChange={(e) => setToken(e.target.value)}
-                placeholder="Paste your bearer token here"
-                spellCheck={false}
-                style={{
-                  width: '100%', padding: '8px 12px',
-                  borderRadius: 'var(--radius-sm)',
-                  border: '1px solid var(--border-primary)',
-                  background: 'var(--bg-secondary)',
-                  color: 'var(--text-primary)',
-                  fontSize: 13, fontFamily: 'var(--font-mono)',
-                  boxSizing: 'border-box',
-                }}
-              />
-              <p style={{ fontSize: 11, color: 'var(--text-tertiary)', marginTop: 4 }}>
-                Bearer token with <code>Item.ReadWrite.All</code> scope.
-                Get one from the Fabric REST API &quot;Try It&quot; page or via MSAL.
-              </p>
-            </div>
-
-            <button
-              className="btn btn-primary"
-              onClick={handleLoadWorkspace}
-              disabled={loading}
-              style={{ width: '100%', display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 8 }}
-            >
-              {loading ? <><Loader2 size={14} className="spin" /> Connecting...</> : 'Connect to Workspace'}
-            </button>
+        {/* Step: Auth */}
+        {step === 'auth' && (
+          <div style={{ textAlign: 'center', padding: '16px 0' }}>
+            {authLoading ? (
+              <>
+                <Loader2 size={32} color="var(--ms-blue)" style={{ animation: 'spin 1s linear infinite', margin: '0 auto' }} />
+                <p style={{ marginTop: 16, fontSize: 14, color: 'var(--text-secondary)' }}>
+                  Connecting to Microsoft…
+                </p>
+                <style>{`@keyframes spin { from { transform: rotate(0deg); } to { transform: rotate(360deg); } }`}</style>
+              </>
+            ) : (
+              <>
+                <div style={{
+                  width: 56, height: 56, margin: '0 auto 16px',
+                  background: 'rgba(0, 102, 179, 0.15)',
+                  borderRadius: 16,
+                  display: 'flex', alignItems: 'center', justifyContent: 'center',
+                }}>
+                  <LogIn size={28} color="var(--ms-blue)" />
+                </div>
+                <p style={{ fontSize: 14, color: 'var(--text-secondary)', marginBottom: 20 }}>
+                  Sign in with your Microsoft account to push this ontology to Fabric.
+                </p>
+                <button
+                  className="btn btn-primary"
+                  onClick={handleSignIn}
+                  style={{ display: 'inline-flex', alignItems: 'center', gap: 8, padding: '10px 24px' }}
+                >
+                  <LogIn size={16} /> Sign in with Microsoft
+                </button>
+              </>
+            )}
           </div>
         )}
 
-        {/* Step: Workspace — choose create or update */}
+        {/* Step: Workspace — pick workspace, then create or update */}
         {step === 'workspace' && (
           <div>
-            <div style={{ marginBottom: 16 }}>
-              <label style={{ display: 'block', fontSize: 13, fontWeight: 600, marginBottom: 8 }}>
-                Action
-              </label>
-              <div style={{ display: 'flex', gap: 8 }}>
-                <button
-                  onClick={() => setMode('create')}
-                  style={{
-                    flex: 1, padding: '10px 16px',
-                    borderRadius: 'var(--radius-sm)',
-                    border: mode === 'create' ? '2px solid var(--ms-blue)' : '2px solid var(--border-primary)',
-                    background: mode === 'create' ? 'rgba(0, 120, 212, 0.1)' : 'var(--bg-secondary)',
-                    color: 'var(--text-primary)',
-                    cursor: 'pointer', fontSize: 13, fontWeight: 600,
-                  }}
-                >
-                  Create New
-                </button>
-                <button
-                  onClick={() => setMode('update')}
-                  disabled={existingOntologies.length === 0}
-                  style={{
-                    flex: 1, padding: '10px 16px',
-                    borderRadius: 'var(--radius-sm)',
-                    border: mode === 'update' ? '2px solid var(--ms-blue)' : '2px solid var(--border-primary)',
-                    background: mode === 'update' ? 'rgba(0, 120, 212, 0.1)' : 'var(--bg-secondary)',
-                    color: existingOntologies.length === 0 ? 'var(--text-tertiary)' : 'var(--text-primary)',
-                    cursor: existingOntologies.length === 0 ? 'not-allowed' : 'pointer',
-                    fontSize: 13, fontWeight: 600,
-                  }}
-                >
-                  Update Existing ({existingOntologies.length})
-                </button>
-              </div>
-            </div>
-
-            {mode === 'update' && existingOntologies.length > 0 && (
-              <div style={{ marginBottom: 16 }}>
-                <label style={{ display: 'block', fontSize: 13, fontWeight: 600, marginBottom: 6 }}>
-                  Select Ontology
-                </label>
-                <select
-                  value={selectedOntologyId}
-                  onChange={(e) => setSelectedOntologyId(e.target.value)}
-                  style={{
-                    width: '100%', padding: '8px 12px',
-                    borderRadius: 'var(--radius-sm)',
-                    border: '1px solid var(--border-primary)',
-                    background: 'var(--bg-secondary)',
-                    color: 'var(--text-primary)',
-                    fontSize: 13,
-                  }}
-                >
-                  <option value="">— Select —</option>
-                  {existingOntologies.map(o => (
-                    <option key={o.id} value={o.id}>
-                      {o.displayName} ({o.id.slice(0, 8)}…)
-                    </option>
-                  ))}
-                </select>
+            {authResult && (
+              <div style={{
+                padding: '8px 12px', marginBottom: 16,
+                background: 'rgba(16, 124, 16, 0.1)',
+                borderRadius: 'var(--radius-sm)',
+                border: '1px solid rgba(16, 124, 16, 0.3)',
+                fontSize: 12, color: '#4CAF50',
+                display: 'flex', alignItems: 'center', gap: 8,
+              }}>
+                <CheckCircle size={14} />
+                Signed in as <strong>{authResult.account.name}</strong>
               </div>
             )}
 
-            <div style={{ display: 'flex', gap: 8, marginTop: 16 }}>
-              <button
-                className="btn btn-secondary"
-                onClick={() => { setStep('credentials'); setError(''); }}
-                style={{ flex: 1 }}
-              >
-                Back
-              </button>
-              <button
-                className="btn btn-primary"
-                onClick={handlePush}
-                disabled={mode === 'update' && !selectedOntologyId}
-                style={{ flex: 2 }}
-              >
-                {mode === 'create' ? 'Create & Push' : 'Update Definition'}
-              </button>
-            </div>
+            {/* Workspace list */}
+            <label style={{ display: 'block', fontSize: 13, fontWeight: 600, marginBottom: 8 }}>
+              Select Workspace
+            </label>
+            {workspacesLoading ? (
+              <div style={{ textAlign: 'center', padding: 24, color: 'var(--text-secondary)', fontSize: 13 }}>
+                <Loader2 size={18} style={{ animation: 'spin 1s linear infinite', display: 'inline-block', marginRight: 8 }} />
+                Loading workspaces…
+              </div>
+            ) : (
+              <div style={{ maxHeight: 180, overflowY: 'auto', marginBottom: 16 }}>
+                {workspaces.length === 0 ? (
+                  <p style={{ fontSize: 12, color: 'var(--text-tertiary)', padding: 12, textAlign: 'center' }}>
+                    No workspaces with Fabric capacity found.
+                  </p>
+                ) : workspaces.map(ws => (
+                  <button
+                    key={ws.id}
+                    onClick={() => handleSelectWorkspace(ws)}
+                    style={{
+                      width: '100%', display: 'flex', alignItems: 'center', gap: 10,
+                      padding: '10px 12px', marginBottom: 4,
+                      borderRadius: 'var(--radius-sm)',
+                      border: selectedWorkspace?.id === ws.id ? '2px solid var(--ms-blue)' : '1px solid var(--border-primary)',
+                      background: selectedWorkspace?.id === ws.id ? 'rgba(0, 102, 179, 0.1)' : 'var(--bg-secondary)',
+                      color: 'var(--text-primary)',
+                      cursor: 'pointer', fontSize: 13, textAlign: 'left',
+                    }}
+                  >
+                    <FolderOpen size={16} style={{ color: selectedWorkspace?.id === ws.id ? 'var(--ms-blue)' : 'var(--text-tertiary)', flexShrink: 0 }} />
+                    <span style={{ flex: 1, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{ws.displayName}</span>
+                    {selectedWorkspace?.id === ws.id && <CheckCircle size={14} color="var(--ms-blue)" style={{ flexShrink: 0 }} />}
+                  </button>
+                ))}
+              </div>
+            )}
+
+            {/* Action: Create or Update */}
+            {selectedWorkspace && (
+              <>
+                <label style={{ display: 'block', fontSize: 13, fontWeight: 600, marginBottom: 8 }}>
+                  Action
+                </label>
+                <div style={{ display: 'flex', gap: 8, marginBottom: 16 }}>
+                  <button
+                    onClick={() => setMode('create')}
+                    style={{
+                      flex: 1, padding: '10px 16px',
+                      borderRadius: 'var(--radius-sm)',
+                      border: mode === 'create' ? '2px solid var(--ms-blue)' : '2px solid var(--border-primary)',
+                      background: mode === 'create' ? 'rgba(0, 102, 179, 0.1)' : 'var(--bg-secondary)',
+                      color: 'var(--text-primary)',
+                      cursor: 'pointer', fontSize: 13, fontWeight: 600,
+                    }}
+                  >
+                    Create New
+                  </button>
+                  <button
+                    onClick={() => setMode('update')}
+                    disabled={existingOntologies.length === 0}
+                    style={{
+                      flex: 1, padding: '10px 16px',
+                      borderRadius: 'var(--radius-sm)',
+                      border: mode === 'update' ? '2px solid var(--ms-blue)' : '2px solid var(--border-primary)',
+                      background: mode === 'update' ? 'rgba(0, 102, 179, 0.1)' : 'var(--bg-secondary)',
+                      color: existingOntologies.length === 0 ? 'var(--text-tertiary)' : 'var(--text-primary)',
+                      cursor: existingOntologies.length === 0 ? 'not-allowed' : 'pointer',
+                      fontSize: 13, fontWeight: 600,
+                    }}
+                  >
+                    {ontologiesLoading ? 'Loading…' : `Update Existing (${existingOntologies.length})`}
+                  </button>
+                </div>
+
+                {mode === 'update' && existingOntologies.length > 0 && (
+                  <div style={{ marginBottom: 16 }}>
+                    <label style={{ display: 'block', fontSize: 13, fontWeight: 600, marginBottom: 6 }}>
+                      Select Ontology
+                    </label>
+                    <select
+                      value={selectedOntologyId}
+                      onChange={(e) => setSelectedOntologyId(e.target.value)}
+                      style={{
+                        width: '100%', padding: '8px 12px',
+                        borderRadius: 'var(--radius-sm)',
+                        border: '1px solid var(--border-primary)',
+                        background: 'var(--bg-secondary)',
+                        color: 'var(--text-primary)',
+                        fontSize: 13,
+                      }}
+                    >
+                      <option value="">— Select —</option>
+                      {existingOntologies.map(o => (
+                        <option key={o.id} value={o.id}>
+                          {o.displayName} ({o.id.slice(0, 8)}…)
+                        </option>
+                      ))}
+                    </select>
+                  </div>
+                )}
+
+                {mode === 'create' && (
+                  <label style={{
+                    display: 'flex', alignItems: 'center', gap: 10,
+                    marginBottom: 16, padding: '10px 12px',
+                    borderRadius: 'var(--radius-sm)',
+                    border: `2px solid ${includeSampleData ? 'var(--ms-blue)' : 'var(--border-primary)'}`,
+                    background: includeSampleData ? 'rgba(0, 102, 179, 0.08)' : 'var(--bg-secondary)',
+                    cursor: 'pointer', fontSize: 13,
+                  }}>
+                    <input
+                      type="checkbox"
+                      checked={includeSampleData}
+                      onChange={(e) => setIncludeSampleData(e.target.checked)}
+                      style={{ accentColor: 'var(--ms-blue)', width: 16, height: 16 }}
+                    />
+                    <Database size={16} style={{ color: 'var(--ms-blue)', flexShrink: 0 }} />
+                    <div>
+                      <div style={{ fontWeight: 600 }}>Include sample data</div>
+                      <div style={{ fontSize: 11, color: 'var(--text-secondary)', marginTop: 2 }}>
+                        Upload realistic data to the Lakehouse and bind to the graph
+                      </div>
+                    </div>
+                  </label>
+                )}
+
+                {mode === 'create' && includeSampleData && (
+                  <label style={{
+                    display: 'flex', alignItems: 'center', gap: 10,
+                    marginBottom: 16, padding: '10px 12px',
+                    borderRadius: 'var(--radius-sm)',
+                    border: `2px solid ${includeDataAgent ? 'var(--ms-blue)' : 'var(--border-primary)'}`,
+                    background: includeDataAgent ? 'rgba(0, 102, 179, 0.08)' : 'var(--bg-secondary)',
+                    cursor: 'pointer', fontSize: 13,
+                  }}>
+                    <input
+                      type="checkbox"
+                      checked={includeDataAgent}
+                      onChange={(e) => setIncludeDataAgent(e.target.checked)}
+                      style={{ accentColor: 'var(--ms-blue)', width: 16, height: 16 }}
+                    />
+                    <Bot size={16} style={{ color: 'var(--ms-blue)', flexShrink: 0 }} />
+                    <div>
+                      <div style={{ fontWeight: 600 }}>Connect Data Agent</div>
+                      <div style={{ fontSize: 11, color: 'var(--text-secondary)', marginTop: 2 }}>
+                        Create an AI agent for natural language queries over the ontology
+                      </div>
+                    </div>
+                  </label>
+                )}
+
+                <button
+                  className="btn btn-primary"
+                  onClick={handlePush}
+                  disabled={mode === 'update' && !selectedOntologyId}
+                  style={{ width: '100%', display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 8 }}
+                >
+                  <Cloud size={16} />
+                  {mode === 'create'
+                    ? `Push "${currentOntology.name}" to ${selectedWorkspace.displayName}`
+                    : 'Update Definition'}
+                </button>
+              </>
+            )}
           </div>
         )}
 
@@ -315,11 +529,38 @@ export function FabricExportModal({ onClose }: FabricExportModalProps) {
           <div style={{ textAlign: 'center', padding: '32px 0' }}>
             <Loader2 size={32} color="var(--ms-blue)" style={{ animation: 'spin 1s linear infinite' }} />
             <p style={{ marginTop: 16, fontSize: 14, color: 'var(--text-secondary)' }}>
-              {mode === 'create' ? 'Creating ontology in Fabric...' : 'Updating ontology definition...'}
+              {statusMessage || (mode === 'create' ? 'Creating ontology in Fabric…' : 'Updating ontology definition…')}
             </p>
-            <p style={{ fontSize: 12, color: 'var(--text-tertiary)', marginTop: 4 }}>
-              This may take a moment while Fabric provisions the resource.
-            </p>
+            {pollProgress ? (
+              <>
+                <div style={{
+                  width: '80%', height: 6, margin: '12px auto 0',
+                  background: 'var(--bg-tertiary)', borderRadius: 3, overflow: 'hidden',
+                }}>
+                  <div style={{
+                    height: '100%', borderRadius: 3,
+                    background: 'var(--ms-blue)',
+                    width: pollProgress.percentComplete != null
+                      ? `${pollProgress.percentComplete}%`
+                      : `${Math.min(90, (pollProgress.attempt / pollProgress.maxAttempts) * 100)}%`,
+                    transition: 'width 0.5s ease',
+                  }} />
+                </div>
+                <p style={{ fontSize: 12, color: 'var(--text-tertiary)', marginTop: 8 }}>
+                  {pollProgress.percentComplete != null
+                    ? `${pollProgress.percentComplete}% complete`
+                    : `Provisioning resources… (${Math.round((pollProgress.attempt * 3))}s)`
+                  }
+                  {pollProgress.status && pollProgress.status !== 'Succeeded' && (
+                    <span> · Status: {pollProgress.status}</span>
+                  )}
+                </p>
+              </>
+            ) : (
+              <p style={{ fontSize: 12, color: 'var(--text-tertiary)', marginTop: 4 }}>
+                Fabric is provisioning Lakehouse, SQL endpoint &amp; GraphModel — this may take up to 2 minutes.
+              </p>
+            )}
 
             <style>{`@keyframes spin { from { transform: rotate(0deg); } to { transform: rotate(360deg); } }`}</style>
           </div>
@@ -328,9 +569,11 @@ export function FabricExportModal({ onClose }: FabricExportModalProps) {
         {/* Step: Done */}
         {step === 'done' && (
           <div style={{ textAlign: 'center', padding: '24px 0' }}>
-            <CheckCircle size={40} color="var(--ms-green)" />
+            <CheckCircle size={40} color="#4CAF50" />
             <p style={{ marginTop: 12, fontSize: 16, fontWeight: 600 }}>
-              {mode === 'create' ? 'Ontology Created!' : 'Definition Updated!'}
+              {mode === 'create'
+                ? (includeSampleData ? 'Ontology Created with Sample Data! 🎉' : 'Ontology Created! 🎉')
+                : 'Definition Updated! ✅'}
             </p>
             {result && (
               <div style={{
@@ -344,13 +587,24 @@ export function FabricExportModal({ onClose }: FabricExportModalProps) {
                 <div><strong>Workspace:</strong> <code style={{ fontSize: 11 }}>{result.workspaceId}</code></div>
               </div>
             )}
-            <button
-              className="btn btn-primary"
-              onClick={onClose}
-              style={{ marginTop: 20 }}
-            >
-              Done
-            </button>
+            {selectedWorkspace && (
+              <a
+                href={`https://app.fabric.microsoft.com/groups/${selectedWorkspace.id}`}
+                target="_blank"
+                rel="noopener noreferrer"
+                style={{
+                  display: 'inline-block', marginTop: 16,
+                  fontSize: 13, color: 'var(--ms-blue)', textDecoration: 'underline',
+                }}
+              >
+                Open workspace in Fabric →
+              </a>
+            )}
+            <div style={{ marginTop: 20 }}>
+              <button className="btn btn-primary" onClick={onClose}>
+                Done
+              </button>
+            </div>
           </div>
         )}
 
@@ -364,11 +618,18 @@ export function FabricExportModal({ onClose }: FabricExportModalProps) {
             <div style={{ display: 'flex', gap: 8, justifyContent: 'center', marginTop: 20 }}>
               <button
                 className="btn btn-secondary"
-                onClick={() => { setStep('credentials'); setError(''); }}
+                onClick={() => { setStep('workspace'); setError(''); }}
                 style={{ display: 'flex', alignItems: 'center', gap: 6 }}
               >
                 <RefreshCw size={14} />
-                Start Over
+                Try Again
+              </button>
+              <button
+                className="btn btn-secondary"
+                onClick={handleCopyDebug}
+                style={{ display: 'flex', alignItems: 'center', gap: 6, fontSize: 12 }}
+              >
+                📋 Copy Debug Info
               </button>
               <button className="btn btn-primary" onClick={onClose}>
                 Close

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -4,7 +4,7 @@ import { useRoute } from '../hooks/useRoute';
 import { routeToHash } from '../lib/router';
 import { encodeSharePayload } from '../lib/shareCodec';
 import { serializeToRDF } from '../lib/rdf/serializer';
-import { Moon, Sun, Database, Trophy, HelpCircle, FileJson, LayoutGrid, Sparkles, FileText, Share2, PenTool, BookOpen, Menu, X, Download, Info } from 'lucide-react';
+import { Moon, Sun, Database, Trophy, HelpCircle, FileJson, LayoutGrid, Sparkles, FileText, Share2, PenTool, BookOpen, Menu, X, Download, Info, Rocket } from 'lucide-react';
 
 interface HeaderProps {
   onAboutClick: () => void;
@@ -16,9 +16,10 @@ interface HeaderProps {
   onLearnClick: () => void;
   onNLBuilderClick?: () => void;
   onSummaryClick: () => void;
+  onDeployClick?: () => void;
 }
 
-export function Header({ onAboutClick, onHelpClick, onDataSourcesClick, onImportExportClick, onGalleryClick, onDesignerClick, onLearnClick, onNLBuilderClick, onSummaryClick }: HeaderProps) {
+export function Header({ onAboutClick, onHelpClick, onDataSourcesClick, onImportExportClick, onGalleryClick, onDesignerClick, onLearnClick, onNLBuilderClick, onSummaryClick, onDeployClick }: HeaderProps) {
   const { darkMode, toggleDarkMode, totalPoints, earnedBadges, currentOntology, dataBindings } = useAppStore();
   const route = useRoute();
   const [shareStatus, setShareStatus] = useState<'idle' | 'copying' | 'copied' | 'downloaded'>('idle');
@@ -86,16 +87,18 @@ export function Header({ onAboutClick, onHelpClick, onDataSourcesClick, onImport
   return (
     <header className="header">
       <div className="header-logo">
-        <svg viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg">
-          <rect width="32" height="32" rx="4" fill="#0078D4"/>
-          <path d="M8 8H15V15H8V8Z" fill="white"/>
-          <path d="M17 8H24V15H17V8Z" fill="white" opacity="0.7"/>
-          <path d="M8 17H15V24H8V17Z" fill="white" opacity="0.7"/>
-          <path d="M17 17H24V24H17V17Z" fill="white" opacity="0.5"/>
-        </svg>
+        <img
+          src="https://www.vattenfall.se/Static/img/logo/VF_logo.svg"
+          alt="Vattenfall"
+          style={{ height: 32, width: 'auto' }}
+          onError={(e) => {
+            // Fallback: hide the image if CDN is unreachable
+            (e.target as HTMLImageElement).style.display = 'none';
+          }}
+        />
         <div>
           <span className="header-title">
-            Ontology Playground <span className="header-title-preview">(Preview)</span>
+            Ontology Playground
           </span>
           <span className="header-context">{ontologyDisplayName}</span>
         </div>
@@ -119,7 +122,7 @@ export function Header({ onAboutClick, onHelpClick, onDataSourcesClick, onImport
           className="header-text-btn"
           onClick={handleShare}
           title={shareableId ? 'Copy shareable link to this ontology' : 'Share this ontology via link'}
-          style={shareStatus === 'copied' ? { color: 'var(--ms-green, #107C10)' } : shareStatus === 'downloaded' ? { color: 'var(--ms-blue, #0078D4)' } : undefined}
+          style={shareStatus === 'copied' ? { color: 'var(--ms-green, #107C10)' } : shareStatus === 'downloaded' ? { color: 'var(--ms-blue, #0066B3)' } : undefined}
         >
           {shareStatus === 'downloaded' ? <Download size={16} /> : <Share2 size={16} />}
           <span>{shareLabel}</span>
@@ -142,6 +145,12 @@ export function Header({ onAboutClick, onHelpClick, onDataSourcesClick, onImport
         <button className="icon-btn" onClick={onLearnClick} data-tooltip="Ontology School" aria-label="Ontology School">
           <BookOpen size={20} />
         </button>
+        {onDeployClick && (
+          <button className="header-text-btn" onClick={onDeployClick} data-tooltip="Push to Fabric" aria-label="Push to Fabric" style={{ color: 'var(--ms-green, #107C10)' }}>
+            <Rocket size={16} />
+            <span>Push</span>
+          </button>
+        )}
         <button className="icon-btn" onClick={onImportExportClick} data-tooltip="Import / Export" aria-label="Import / Export">
           <FileJson size={20} />
         </button>
@@ -195,6 +204,11 @@ export function Header({ onAboutClick, onHelpClick, onDataSourcesClick, onImport
             <button className="mobile-menu-item" onClick={menuAction(onLearnClick)}>
               <BookOpen size={18} /> Ontology School
             </button>
+            {onDeployClick && (
+              <button className="mobile-menu-item" onClick={menuAction(onDeployClick)}>
+                <Rocket size={18} /> Push to Fabric
+              </button>
+            )}
             <button className="mobile-menu-item" onClick={menuAction(onImportExportClick)}>
               <FileJson size={18} /> Import / Export
             </button>

--- a/src/lib/fabric.test.ts
+++ b/src/lib/fabric.test.ts
@@ -1,5 +1,5 @@
-import { describe, it, expect } from 'vitest';
-import { convertToFabricParts } from './fabric';
+import { describe, it, expect, beforeAll } from 'vitest';
+import { convertToFabricParts, validateForFabric, FabricValidationError } from './fabric';
 import type { Ontology } from '../data/ontology';
 
 function decode(base64: string): unknown {
@@ -137,12 +137,13 @@ describe('convertToFabricParts', () => {
 
     const customer = decode(customerPart!.payload) as {
       entityIdParts: string[];
-      displayNamePropertyId: string;
+      displayNamePropertyId: string | null;
       properties: Array<{ id: string; name: string }>;
     };
 
     const customerIdProp = customer.properties.find(p => p.name === 'customerId');
     expect(customer.entityIdParts).toEqual([customerIdProp!.id]);
+    // displayNamePropertyId should be set to the identifier property's ID (per Fabric spec)
     expect(customer.displayNamePropertyId).toBe(customerIdProp!.id);
   });
 
@@ -161,7 +162,7 @@ describe('convertToFabricParts', () => {
     expect(rel.target.entityTypeId).toBe(entityIdMap.get('order'));
   });
 
-  it('skips relationships referencing unknown entities', () => {
+  it('throws for relationships referencing unknown entities', () => {
     const ontologyWithBadRel: Ontology = {
       ...minimalOntology,
       relationships: [
@@ -176,11 +177,7 @@ describe('convertToFabricParts', () => {
       ],
     };
 
-    const { definition } = convertToFabricParts(ontologyWithBadRel);
-    const relParts = definition.parts.filter(p => p.path.startsWith('RelationshipTypes/'));
-
-    // Only the valid relationship should be included
-    expect(relParts).toHaveLength(1);
+    expect(() => convertToFabricParts(ontologyWithBadRel)).toThrow(/nonexistent/);
   });
 
   it('generates unique numeric IDs', () => {
@@ -229,13 +226,18 @@ describe('convertToFabricParts', () => {
   it('platform part contains correct metadata', () => {
     const { definition } = convertToFabricParts(minimalOntology);
     const platformPart = definition.parts.find(p => p.path === '.platform');
+    expect(platformPart).toBeDefined();
 
     const platform = decode(platformPart!.payload) as {
+      $schema: string;
       metadata: { type: string; displayName: string };
+      config: { version: string; logicalId: string };
     };
 
+    expect(platform.$schema).toContain('platformProperties');
     expect(platform.metadata.type).toBe('Ontology');
-    expect(platform.metadata.displayName).toBe('Test Ontology');
+    expect(platform.metadata.displayName).toBe('Test_Ontology');
+    expect(platform.config.version).toBe('2.0');
   });
 
   it('definition.json part is empty object', () => {
@@ -266,11 +268,282 @@ describe('convertToFabricParts', () => {
     const { definition } = convertToFabricParts(ontology);
     const entityPart = definition.parts.find(p => p.path.startsWith('EntityTypes/'));
     const entity = decode(entityPart!.payload) as {
-      properties: unknown[];
-      entityIdParts: unknown[];
+      properties: { name: string; valueType: string }[];
+      entityIdParts: string[];
+      displayNamePropertyId: string | null;
     };
 
-    expect(entity.properties).toHaveLength(0);
-    expect(entity.entityIdParts).toHaveLength(0);
+    // Entities with no properties get a synthetic "Id" property so Fabric can import them
+    expect(entity.properties).toHaveLength(1);
+    expect(entity.properties[0].name).toBe('Id');
+    expect(entity.properties[0].valueType).toBe('String');
+    expect(entity.entityIdParts).toHaveLength(1);
+    // displayNamePropertyId should be set to the synthetic Id property's ID
+    expect(entity.displayNamePropertyId).toBe(entity.entityIdParts[0]);
+  });
+
+  it('disambiguates cross-entity property name conflicts with different types', () => {
+    const ontology: Ontology = {
+      name: 'ConflictTest',
+      description: '',
+      entityTypes: [
+        {
+          id: 'a', name: 'Policy', description: '', icon: '📦', color: '#000',
+          properties: [
+            { name: 'id', type: 'string', isIdentifier: true },
+            { name: 'severity', type: 'string' },  // String
+          ],
+        },
+        {
+          id: 'b', name: 'Failure', description: '', icon: '📦', color: '#000',
+          properties: [
+            { name: 'id', type: 'string', isIdentifier: true },
+            { name: 'severity', type: 'integer' },  // BigInt — conflicts!
+          ],
+        },
+      ],
+      relationships: [],
+    };
+
+    const { definition } = convertToFabricParts(ontology);
+    const entityParts = definition.parts.filter(p => p.path.startsWith('EntityTypes/'));
+
+    const policyPart = entityParts.find(p => {
+      const d = decode(p.payload) as { name: string };
+      return d.name === 'Policy';
+    });
+    const failurePart = entityParts.find(p => {
+      const d = decode(p.payload) as { name: string };
+      return d.name === 'Failure';
+    });
+
+    const policySeverity = (decode(policyPart!.payload) as { properties: { name: string }[] }).properties.find(p => p.name.startsWith('severity'));
+    const failureSeverity = (decode(failurePart!.payload) as { properties: { name: string }[] }).properties.find(p => p.name.startsWith('severity'));
+
+    // Both should exist but with different disambiguated names
+    expect(policySeverity).toBeDefined();
+    expect(failureSeverity).toBeDefined();
+    expect(policySeverity!.name).not.toBe(failureSeverity!.name);
+    // Each should contain the entity name suffix
+    expect(policySeverity!.name).toBe('severity_Policy');
+    expect(failureSeverity!.name).toBe('severity_Failure');
+  });
+
+  it('disambiguates duplicate relationship names by appending source entity name', () => {
+    const ontology: Ontology = {
+      name: 'RelDupTest',
+      description: '',
+      entityTypes: [
+        { id: 'policy', name: 'MaintenancePolicy', description: '', icon: '📦', color: '#000', properties: [{ name: 'id', type: 'string', isIdentifier: true }] },
+        { id: 'bulletin', name: 'OEMBulletin', description: '', icon: '📦', color: '#000', properties: [{ name: 'id', type: 'string', isIdentifier: true }] },
+        { id: 'gen', name: 'Generator', description: '', icon: '📦', color: '#000', properties: [{ name: 'id', type: 'string', isIdentifier: true }] },
+      ],
+      relationships: [
+        { id: 'r1', name: 'applies_to', from: 'policy', to: 'gen', cardinality: 'one-to-many' },
+        { id: 'r2', name: 'applies_to', from: 'bulletin', to: 'gen', cardinality: 'one-to-many' },
+      ],
+    };
+
+    const { definition } = convertToFabricParts(ontology);
+    const relParts = definition.parts.filter(p => p.path.startsWith('RelationshipTypes/'));
+    expect(relParts).toHaveLength(2);
+
+    const relNames = relParts.map(p => (decode(p.payload) as { name: string }).name);
+    // Both should be disambiguated with source entity name
+    expect(relNames).toContain('applies_to_MaintenancePolicy');
+    expect(relNames).toContain('applies_to_OEMBulletin');
+    // No duplicates
+    expect(new Set(relNames).size).toBe(2);
+  });
+});
+
+describe('validateForFabric', () => {
+  const validOntology: Ontology = {
+    name: 'Valid',
+    description: '',
+    entityTypes: [
+      { id: 'a', name: 'Alpha', description: '', icon: '📦', color: '#000', properties: [{ name: 'Id', type: 'string', isIdentifier: true }] },
+      { id: 'b', name: 'Beta', description: '', icon: '📦', color: '#000', properties: [{ name: 'Id', type: 'string', isIdentifier: true }] },
+    ],
+    relationships: [{ id: 'r1', name: 'links', from: 'a', to: 'b', cardinality: 'one-to-many' }],
+  };
+
+  it('passes for valid ontology', () => {
+    expect(() => validateForFabric(validOntology)).not.toThrow();
+  });
+
+  it('detects duplicate entity names after sanitization', () => {
+    const dup: Ontology = {
+      ...validOntology,
+      entityTypes: [
+        { id: 'a', name: 'Wind Turbine', description: '', icon: '📦', color: '#000', properties: [] },
+        { id: 'b', name: 'Wind-Turbine', description: '', icon: '📦', color: '#000', properties: [] },
+      ],
+      relationships: [],
+    };
+    expect(() => validateForFabric(dup)).toThrow(/collision/i);
+  });
+
+  it('detects duplicate property names after sanitization', () => {
+    const dup: Ontology = {
+      ...validOntology,
+      entityTypes: [
+        {
+          id: 'a', name: 'Thing', description: '', icon: '📦', color: '#000',
+          properties: [
+            { name: 'my prop', type: 'string' },
+            { name: 'my-prop', type: 'string' },
+          ],
+        },
+      ],
+      relationships: [],
+    };
+    expect(() => validateForFabric(dup)).toThrow(/collision/i);
+  });
+
+  it('detects unresolved relationship refs', () => {
+    const bad: Ontology = {
+      ...validOntology,
+      relationships: [{ id: 'r1', name: 'broken', from: 'a', to: 'missing', cardinality: 'one-to-many' }],
+    };
+    expect(() => validateForFabric(bad)).toThrow(/unknown/i);
+  });
+
+  it('allows duplicate relationship names (auto-disambiguated by convertToFabricParts)', () => {
+    const dup: Ontology = {
+      ...validOntology,
+      relationships: [
+        { id: 'r1', name: 'has items', from: 'a', to: 'b', cardinality: 'one-to-many' },
+        { id: 'r2', name: 'has-items', from: 'a', to: 'b', cardinality: 'one-to-many' },
+      ],
+    };
+    // validateForFabric no longer blocks on duplicate rel names — conversion handles it
+    expect(() => validateForFabric(dup)).not.toThrow();
+  });
+
+  it('detects duplicate entity IDs', () => {
+    const dup: Ontology = {
+      ...validOntology,
+      entityTypes: [
+        { id: 'same', name: 'Alpha', description: '', icon: '📦', color: '#000', properties: [] },
+        { id: 'same', name: 'Beta', description: '', icon: '📦', color: '#000', properties: [] },
+      ],
+      relationships: [],
+    };
+    expect(() => validateForFabric(dup)).toThrow(/Duplicate entity ID/i);
+  });
+
+  it('throws FabricValidationError (not FabricApiError)', () => {
+    const bad: Ontology = {
+      ...validOntology,
+      relationships: [{ id: 'r1', name: 'broken', from: 'a', to: 'missing', cardinality: 'one-to-many' }],
+    };
+    expect(() => validateForFabric(bad)).toThrow(FabricValidationError);
+  });
+});
+
+describe('generateEdgeTables', () => {
+  let generateEdgeTables: typeof import('./fabric').generateEdgeTables;
+  beforeAll(async () => {
+    generateEdgeTables = (await import('./fabric')).generateEdgeTables;
+  });
+
+  const ontology: Ontology = {
+    name: 'Test',
+    description: '',
+    entityTypes: [
+      { id: 'farm', name: 'WindFarm', description: '', icon: '🌊', color: '#000',
+        properties: [{ name: 'farmId', type: 'string', isIdentifier: true }, { name: 'name', type: 'string' }] },
+      { id: 'turbine', name: 'Turbine', description: '', icon: '🔧', color: '#000',
+        properties: [{ name: 'turbineId', type: 'string', isIdentifier: true }, { name: 'model', type: 'string' }] },
+      { id: 'gen', name: 'Generator', description: '', icon: '⚡', color: '#000',
+        properties: [{ name: 'generatorId', type: 'string', isIdentifier: true }] },
+    ],
+    relationships: [
+      { id: 'r1', name: 'contains', from: 'farm', to: 'turbine', cardinality: 'one-to-many' },
+      { id: 'r2', name: 'has_generator', from: 'turbine', to: 'gen', cardinality: 'one-to-one' },
+    ],
+  };
+
+  const sampleTables = new Map([
+    ['WindFarm', [
+      { id: 'wf1', entityTypeId: 'farm', values: { farmId: 'WF-001', name: 'Farm A' } },
+      { id: 'wf2', entityTypeId: 'farm', values: { farmId: 'WF-002', name: 'Farm B' } },
+    ]],
+    ['Turbine', [
+      { id: 't1', entityTypeId: 'turbine', values: { turbineId: 'T-001', model: 'V164' } },
+      { id: 't2', entityTypeId: 'turbine', values: { turbineId: 'T-002', model: 'SG11' } },
+      { id: 't3', entityTypeId: 'turbine', values: { turbineId: 'T-003', model: 'V164' } },
+    ]],
+    ['Generator', [
+      { id: 'g1', entityTypeId: 'gen', values: { generatorId: 'G-001' } },
+      { id: 'g2', entityTypeId: 'gen', values: { generatorId: 'G-002' } },
+    ]],
+  ]);
+
+  it('generates edge tables for all relationships with sample data', () => {
+    const { edgeInstances, edgeMeta } = generateEdgeTables(ontology, sampleTables);
+    expect(edgeMeta).toHaveLength(2);
+    expect(edgeInstances.size).toBe(2);
+  });
+
+  it('produces correct one-to-many edges (round-robin source assignment)', () => {
+    const { edgeInstances, edgeMeta } = generateEdgeTables(ontology, sampleTables);
+    const containsMeta = edgeMeta.find(m => m.relationshipName === 'contains')!;
+    const containsRows = edgeInstances.get(containsMeta.tableName)!;
+    // 3 turbines → 3 edges, round-robin across 2 farms
+    expect(containsRows).toHaveLength(3);
+    expect(containsRows[0].values.sourceId).toBe('WF-001');
+    expect(containsRows[0].values.targetId).toBe('T-001');
+    expect(containsRows[1].values.sourceId).toBe('WF-002');
+    expect(containsRows[2].values.sourceId).toBe('WF-001'); // wraps around
+  });
+
+  it('produces correct one-to-one edges (min pairing)', () => {
+    const { edgeInstances, edgeMeta } = generateEdgeTables(ontology, sampleTables);
+    const genMeta = edgeMeta.find(m => m.relationshipName === 'has_generator')!;
+    const genRows = edgeInstances.get(genMeta.tableName)!;
+    // 3 turbines vs 2 generators → min(3,2) = 2 edges
+    expect(genRows).toHaveLength(2);
+  });
+
+  it('uses ontology isIdentifier for PK column name', () => {
+    const { edgeMeta } = generateEdgeTables(ontology, sampleTables);
+    const containsMeta = edgeMeta.find(m => m.relationshipName === 'contains')!;
+    expect(containsMeta.sourcePkColumn).toBe('farmId');
+    expect(containsMeta.destPkColumn).toBe('turbineId');
+  });
+
+  it('stores sanitized entity names in metadata', () => {
+    const { edgeMeta } = generateEdgeTables(ontology, sampleTables);
+    for (const m of edgeMeta) {
+      expect(m.sourceEntityName).not.toContain(' ');
+      expect(m.destEntityName).not.toContain(' ');
+    }
+  });
+
+  it('skips relationships where entity has no sample data', () => {
+    const partial = new Map([['WindFarm', sampleTables.get('WindFarm')!]]);
+    const { edgeMeta } = generateEdgeTables(ontology, partial);
+    expect(edgeMeta).toHaveLength(0);
+  });
+
+  it('deduplicates many-to-many edges', () => {
+    const m2mOntology: Ontology = {
+      ...ontology,
+      relationships: [{ id: 'r3', name: 'affects', from: 'farm', to: 'turbine', cardinality: 'many-to-many' }],
+    };
+    const { edgeInstances, edgeMeta } = generateEdgeTables(m2mOntology, sampleTables);
+    const rows = edgeInstances.get(edgeMeta[0].tableName)!;
+    const pairs = rows.map(r => `${r.values.sourceId}|${r.values.targetId}`);
+    expect(new Set(pairs).size).toBe(pairs.length);
+  });
+
+  it('creates unique edge table names that do not collide with entity tables', () => {
+    const { edgeMeta } = generateEdgeTables(ontology, sampleTables);
+    const entityTableNames = [...sampleTables.keys()].map(n => n.replace(/[^a-zA-Z0-9_]/g, ''));
+    for (const m of edgeMeta) {
+      expect(entityTableNames).not.toContain(m.tableName);
+    }
   });
 });

--- a/src/lib/fabric.ts
+++ b/src/lib/fabric.ts
@@ -35,7 +35,7 @@ export interface FabricEntityType {
   baseEntityTypeId: null;
   name: string;
   entityIdParts: string[];
-  displayNamePropertyId: string;
+  displayNamePropertyId: string | null;
   namespaceType: 'Custom';
   visibility: 'Visible';
   properties: FabricEntityTypeProperty[];
@@ -75,15 +75,22 @@ export interface FabricListOntologiesResponse {
 /**
  * Generate a positive 64-bit integer ID as a string, matching Fabric's
  * requirement for entity/property/relationship IDs.
+ * Pass a Set to guarantee uniqueness within a conversion run.
  */
-function generateFabricId(): string {
-  // Use crypto.getRandomValues for a 53-bit positive integer
-  // (stays within JS safe integer range)
-  const buf = new Uint32Array(2);
-  crypto.getRandomValues(buf);
-  const high = buf[0] & 0x001FFFFF;  // 21 bits
-  const low = buf[1];                 // 32 bits
-  return String(high * 0x100000000 + low);
+function generateFabricId(usedIds?: Set<string>): string {
+  for (let attempt = 0; attempt < 10; attempt++) {
+    const buf = new Uint32Array(2);
+    crypto.getRandomValues(buf);
+    const high = buf[0] & 0x001FFFFF;  // 21 bits
+    const low = buf[1];                 // 32 bits
+    const val = high * 0x100000000 + low;
+    if (val === 0) continue;
+    const id = String(val);
+    if (usedIds && usedIds.has(id)) continue;
+    usedIds?.add(id);
+    return id;
+  }
+  return String(Date.now()); // last-resort fallback
 }
 
 // ─── Type mapping ──────────────────────────────────────────────────────────
@@ -118,7 +125,73 @@ function toBase64(obj: unknown): string {
 
 export interface ConversionResult {
   definition: FabricOntologyDefinition;
-  entityIdMap: Map<string, string>;  // playground id → fabric id
+  entityIdMap: Map<string, string>;     // playground id → fabric id
+  propertyIdMap: Map<string, Map<string, string>>;  // playground entity id → (propName → fabric prop id)
+  entityNameMap: Map<string, string>;   // playground entity id → sanitized fabric name
+}
+
+export class FabricValidationError extends Error {
+  readonly errors: string[];
+
+  constructor(errors: string[]) {
+    super(`Ontology validation failed:\n• ${errors.join('\n• ')}`);
+    this.name = 'FabricValidationError';
+    this.errors = errors;
+  }
+}
+
+/**
+ * Preflight validation — checks the ontology for issues that would cause
+ * Fabric import failures. Throws with a human-readable message on failure.
+ */
+export function validateForFabric(ontology: Ontology): void {
+  const errors: string[] = [];
+
+  // Check for duplicate entity IDs
+  const seenEntityIds = new Set<string>();
+  for (const entity of ontology.entityTypes) {
+    if (seenEntityIds.has(entity.id)) {
+      errors.push(`Duplicate entity ID: "${entity.id}" appears more than once`);
+    }
+    seenEntityIds.add(entity.id);
+  }
+
+  const entityIds = new Set(ontology.entityTypes.map(e => e.id));
+
+  // Check for duplicate entity names after sanitization
+  const sanitizedEntityNames = new Map<string, string>();
+  for (const entity of ontology.entityTypes) {
+    const sName = sanitizeName(entity.name);
+    if (sanitizedEntityNames.has(sName)) {
+      errors.push(`Entity name collision: "${entity.name}" and "${sanitizedEntityNames.get(sName)}" both become "${sName}" after sanitization`);
+    }
+    sanitizedEntityNames.set(sName, entity.name);
+
+    // Check for duplicate property names within an entity after sanitization
+    const sanitizedPropNames = new Map<string, string>();
+    for (const prop of entity.properties) {
+      const sProp = sanitizeName(prop.name);
+      if (sanitizedPropNames.has(sProp)) {
+        errors.push(`Property collision in "${entity.name}": "${prop.name}" and "${sanitizedPropNames.get(sProp)}" both become "${sProp}"`);
+      }
+      sanitizedPropNames.set(sProp, prop.name);
+    }
+  }
+
+  // Check relationship references (duplicate names are OK — Fabric uses unique IDs)
+  for (const rel of ontology.relationships) {
+    // Check for unresolved entity references
+    if (!entityIds.has(rel.from)) {
+      errors.push(`Relationship "${rel.name}" references unknown source entity "${rel.from}"`);
+    }
+    if (!entityIds.has(rel.to)) {
+      errors.push(`Relationship "${rel.name}" references unknown target entity "${rel.to}"`);
+    }
+  }
+
+  if (errors.length > 0) {
+    throw new FabricValidationError(errors);
+  }
 }
 
 /**
@@ -128,13 +201,20 @@ export interface ConversionResult {
 export function convertToFabricParts(ontology: Ontology): ConversionResult {
   const parts: FabricDefinitionPart[] = [];
   const entityIdMap = new Map<string, string>();
-  const propertyIdMap = new Map<string, Map<string, string>>(); // entityId → (propName → fabricId)
+  const propertyIdMap = new Map<string, Map<string, string>>();
+  const entityNameMap = new Map<string, string>();
+  const usedIds = new Set<string>(); // guarantees unique Fabric IDs
 
-  // Platform part
+  // Platform part — required by Fabric definition schema
   const platform = {
+    $schema: 'https://developer.microsoft.com/json-schemas/fabric/gitIntegration/platformProperties/2.0.0/schema.json',
     metadata: {
       type: 'Ontology',
-      displayName: ontology.name,
+      displayName: sanitizeItemName(ontology.name),
+    },
+    config: {
+      version: '2.0',
+      logicalId: '00000000-0000-0000-0000-000000000000',
     },
   };
   parts.push({
@@ -143,45 +223,73 @@ export function convertToFabricParts(ontology: Ontology): ConversionResult {
     payloadType: 'InlineBase64',
   });
 
-  // Empty definition.json (required)
+  // definition.json — empty root (required by Fabric)
   parts.push({
     path: 'definition.json',
     payload: toBase64({}),
     payloadType: 'InlineBase64',
   });
 
+  // Build global property name → valueType map to detect cross-entity conflicts.
+  // Fabric requires that properties with the same name have the same type globally.
+  const globalPropTypes = new Map<string, string>(); // sanitizedName → valueType
+  const conflictingProps = new Set<string>(); // sanitizedNames that have type conflicts
+  for (const entity of ontology.entityTypes) {
+    const props = entity.properties.length > 0
+      ? entity.properties
+      : [{ name: 'Id', type: 'string' as const }];
+    for (const prop of props) {
+      const sName = sanitizeName(prop.name);
+      const vType = mapValueType(prop.type);
+      const existing = globalPropTypes.get(sName);
+      if (existing && existing !== vType) {
+        conflictingProps.add(sName);
+      }
+      if (!existing) globalPropTypes.set(sName, vType);
+    }
+  }
+
   // Entity Types
   for (const entity of ontology.entityTypes) {
-    const fabricEntityId = generateFabricId();
+    const fabricEntityId = generateFabricId(usedIds);
     entityIdMap.set(entity.id, fabricEntityId);
+    entityNameMap.set(entity.id, sanitizeName(entity.name));
 
     const propMap = new Map<string, string>();
     propertyIdMap.set(entity.id, propMap);
 
-    // Build properties
-    const fabricProperties: FabricEntityTypeProperty[] = entity.properties.map(prop => {
-      const fabricPropId = generateFabricId();
+    // Inject synthetic "Id" if entity has no properties
+    const sourceProps = entity.properties.length > 0
+      ? entity.properties
+      : [{ name: 'Id', type: 'string' as const, isIdentifier: true }];
+
+    const fabricProperties: FabricEntityTypeProperty[] = sourceProps.map(prop => {
+      const fabricPropId = generateFabricId(usedIds);
       propMap.set(prop.name, fabricPropId);
+      let propName = sanitizeName(prop.name);
+      // Disambiguate cross-entity property name conflicts by suffixing entity name
+      if (conflictingProps.has(propName)) {
+        propName = `${propName}_${sanitizeName(entity.name)}`.slice(0, 128);
+      }
       return {
         id: fabricPropId,
-        name: sanitizeName(prop.name),
+        name: propName,
         redefines: null,
         baseTypeNamespaceType: null,
         valueType: mapValueType(prop.type),
       };
     });
 
-    // Pick identifier: first isIdentifier property, or first property
-    const identifierProp = entity.properties.find(p => p.isIdentifier) || entity.properties[0];
-    const identifierFabricId = identifierProp ? propMap.get(identifierProp.name)! : fabricProperties[0]?.id;
+    const identifierProp = sourceProps.find(p => 'isIdentifier' in p && p.isIdentifier) || sourceProps[0];
+    const identifierFabricId = propMap.get(identifierProp.name)!;
 
     const fabricEntity: FabricEntityType = {
       id: fabricEntityId,
       namespace: 'usertypes',
       baseEntityTypeId: null,
       name: sanitizeName(entity.name),
-      entityIdParts: identifierFabricId ? [identifierFabricId] : [],
-      displayNamePropertyId: identifierFabricId ?? '',
+      entityIdParts: [identifierFabricId],
+      displayNamePropertyId: identifierFabricId,
       namespaceType: 'Custom',
       visibility: 'Visible',
       properties: fabricProperties,
@@ -195,22 +303,53 @@ export function convertToFabricParts(ontology: Ontology): ConversionResult {
     });
   }
 
-  // Relationship Types
+  // Detect duplicate relationship names so we can auto-disambiguate.
+  // Fabric enforces globally unique relationship names.
+  const relNameCounts = new Map<string, number>();
   for (const rel of ontology.relationships) {
-    const fabricRelId = generateFabricId();
+    const sName = sanitizeName(rel.name);
+    relNameCounts.set(sName, (relNameCounts.get(sName) || 0) + 1);
+  }
+  const duplicateRelNames = new Set(
+    [...relNameCounts.entries()].filter(([, c]) => c > 1).map(([n]) => n),
+  );
+
+  // Relationship Types
+  const usedRelNames = new Set<string>();
+  for (const rel of ontology.relationships) {
+    const fabricRelId = generateFabricId(usedIds);
     const sourceEntityId = entityIdMap.get(rel.from);
     const targetEntityId = entityIdMap.get(rel.to);
 
     if (!sourceEntityId || !targetEntityId) {
-      // Skip relationships referencing unknown entities
-      continue;
+      const missing = !sourceEntityId ? rel.from : rel.to;
+      throw new FabricApiError(
+        `Relationship "${rel.name}" references entity "${missing}" which does not exist in the ontology`,
+        422,
+        'InvalidRelationship',
+      );
     }
 
-    const fabricRel: FabricRelationshipType = {
-      namespace: 'usertypes',
+    // Disambiguate duplicate relationship names by appending source entity name
+    let relName = sanitizeName(rel.name);
+    if (duplicateRelNames.has(relName)) {
+      const sourceEntity = ontology.entityTypes.find(e => e.id === rel.from);
+      const suffix = sourceEntity ? sanitizeName(sourceEntity.name) : rel.from;
+      relName = `${relName}_${suffix}`.slice(0, 128);
+    }
+    // Final dedup: if still collides (e.g., same source), append numeric suffix
+    const baseRelName = relName;
+    let counter = 2;
+    while (usedRelNames.has(relName)) {
+      relName = `${baseRelName}_${counter++}`.slice(0, 128);
+    }
+    usedRelNames.add(relName);
+
+    const fabricRel = {
+      namespace: 'usertypes' as const,
       id: fabricRelId,
-      name: sanitizeName(rel.name),
-      namespaceType: 'Custom',
+      name: relName,
+      namespaceType: 'Custom' as const,
       source: { entityTypeId: sourceEntityId },
       target: { entityTypeId: targetEntityId },
     };
@@ -225,21 +364,34 @@ export function convertToFabricParts(ontology: Ontology): ConversionResult {
   return {
     definition: { parts },
     entityIdMap,
+    propertyIdMap,
+    entityNameMap,
   };
 }
 
 /**
- * Sanitize a name to match Fabric's regex: ^[a-zA-Z][a-zA-Z0-9_-]{0,127}$
+ * Sanitize an internal name (entity types, properties, relationships).
+ * Fabric allows only: letters, numbers, underscores; must start with a letter.
  */
 function sanitizeName(name: string): string {
-  // Replace spaces and invalid chars with underscores
-  let sanitized = name.replace(/[^a-zA-Z0-9_-]/g, '_');
-  // Ensure starts with a letter
+  let sanitized = name.replace(/[^a-zA-Z0-9_]+/g, '_').replace(/^_+|_+$/g, '');
   if (sanitized.length === 0 || !/^[a-zA-Z]/.test(sanitized)) {
     sanitized = 'E_' + sanitized;
   }
-  // Truncate to 128 characters
   return sanitized.slice(0, 128);
+}
+
+/**
+ * Sanitize an item display name for Fabric's stricter item-level rules:
+ * must start with a letter, < 90 chars, only letters, numbers, underscores.
+ */
+export function sanitizeItemName(name: string): string {
+  // Collapse spaces/dashes/special chars to single underscores, strip leading/trailing _
+  let sanitized = name.replace(/[^a-zA-Z0-9_]+/g, '_').replace(/^_+|_+$/g, '');
+  if (sanitized.length === 0 || !/^[a-zA-Z]/.test(sanitized)) {
+    sanitized = 'Ontology_' + sanitized;
+  }
+  return sanitized.slice(0, 89);
 }
 
 // ─── Fabric REST API client ────────────────────────────────────────────────
@@ -294,6 +446,14 @@ async function fabricFetch<T>(
     } catch {
       // Use default message
     }
+    // Add context for common 500 errors
+    if (res.status === 500 && !errorCode) {
+      message += ' — this often means an ontology with the same name already exists in the workspace. Try updating instead of creating.';
+    }
+    // Capacity not active is returned as 404 with errorCode "CapacityNotActive"
+    if (errorCode === 'CapacityNotActive') {
+      message = 'The Fabric capacity assigned to this workspace is paused or inactive. Please resume it in the Azure portal and try again.';
+    }
     throw new FabricApiError(message, res.status, errorCode);
   }
 
@@ -302,14 +462,24 @@ async function fabricFetch<T>(
   return { data };
 }
 
+export interface PollProgress {
+  attempt: number;
+  maxAttempts: number;
+  status?: string;
+  percentComplete?: number;
+}
+
 /**
  * Poll a long-running operation until completion.
+ * Default timeout: 60 attempts × 3s = ~3 minutes (Fabric ontology creation
+ * provisions Lakehouse + SQL endpoint + GraphModel and can take 60-90s).
  */
 async function pollOperation(
   operationId: string,
   token: string,
-  maxAttempts = 20,
-  intervalMs = 2000,
+  maxAttempts = 60,
+  intervalMs = 3000,
+  onProgress?: (progress: PollProgress) => void,
 ): Promise<void> {
   for (let i = 0; i < maxAttempts; i++) {
     await new Promise(resolve => setTimeout(resolve, intervalMs));
@@ -320,26 +490,93 @@ async function pollOperation(
 
     if (res.ok) {
       const body = await res.json();
+      onProgress?.({
+        attempt: i + 1,
+        maxAttempts,
+        status: body.status,
+        percentComplete: body.percentComplete,
+      });
+
       if (body.status === 'Succeeded') return;
       if (body.status === 'Failed') {
+        // Log full error for debugging
+        console.error('🔧 Fabric operation failed:', JSON.stringify(body, null, 2));
+
+        // Try to get more details from the operation result
+        try {
+          const resultRes = await fetch(`${FABRIC_API_BASE}/operations/${operationId}/result`, {
+            headers: { 'Authorization': `Bearer ${token}` },
+          });
+          if (!resultRes.ok) {
+            const resultBody = await resultRes.text();
+            console.error('🔧 Operation result details:', resultBody);
+          }
+        } catch { /* ignore */ }
+
+        const errorMsg = body.error?.message ?? 'Operation failed';
+        const errorCode = body.error?.errorCode;
         throw new FabricApiError(
-          body.error?.message ?? 'Operation failed',
-          400,
-          body.error?.errorCode,
+          errorMsg,
+          body.error?.statusCode ?? 400,
+          errorCode,
         );
+      }
+
+      // Respect Retry-After header if present
+      const retryAfter = res.headers.get('Retry-After');
+      if (retryAfter) {
+        const delaySec = parseInt(retryAfter, 10);
+        if (!isNaN(delaySec) && delaySec > 0) {
+          await new Promise(resolve => setTimeout(resolve, delaySec * 1000));
+        }
       }
       // Still running — continue polling
     } else if (res.status === 202) {
-      // Still in progress
+      onProgress?.({ attempt: i + 1, maxAttempts, status: 'Running' });
       continue;
     } else {
       throw new FabricApiError(`Failed to poll operation: ${res.status}`, res.status);
     }
   }
-  throw new FabricApiError('Operation timed out', 408);
+  throw new FabricApiError(
+    'Operation timed out after 3 minutes. The ontology may still be provisioning — check your Fabric workspace.',
+    408,
+  );
 }
 
 // ─── Public API ────────────────────────────────────────────────────────────
+
+/**
+ * Fetch the current definition of an ontology from Fabric.
+ * Returns the parts array, or null if the operation fails.
+ * getDefinition is async (202) — we poll the operation then fetch the result.
+ */
+async function getDefinition(
+  workspaceId: string,
+  ontologyId: string,
+  token: string,
+): Promise<FabricDefinitionPart[] | null> {
+  try {
+    const result = await fabricFetch<{ definition: FabricOntologyDefinition } | null>(
+      `/workspaces/${encodeURIComponent(workspaceId)}/ontologies/${encodeURIComponent(ontologyId)}/getDefinition`,
+      token,
+      { method: 'POST' },
+    );
+    // If 202, poll the operation and get the result
+    if (!result.data && result.operationId) {
+      await pollOperation(result.operationId, token, 20, 3000);
+      // Fetch the result from the operation
+      const opResult = await fabricFetch<{ definition: FabricOntologyDefinition }>(
+        `/operations/${result.operationId}/result`,
+        token,
+      );
+      return opResult.data?.definition?.parts ?? null;
+    }
+    return result.data?.definition?.parts ?? null;
+  } catch {
+    return null;
+  }
+}
 
 /**
  * List ontologies in a Fabric workspace.
@@ -357,19 +594,50 @@ export async function listOntologies(
 
 /**
  * Create a new ontology in a Fabric workspace and push its definition.
+ * If an ontology with the same name already exists, appends a numeric suffix.
  */
 export async function createOntology(
   workspaceId: string,
   token: string,
   ontology: Ontology,
+  onProgress?: (progress: PollProgress) => void,
 ): Promise<FabricOntologyResponse> {
+  // Preflight validation — catch data issues before hitting Fabric
+  validateForFabric(ontology);
+
   const { definition } = convertToFabricParts(ontology);
 
+  // Deduplicate display name to avoid 500 from Fabric on name collision
+  let displayName = sanitizeItemName(ontology.name);
+  try {
+    const existing = await listOntologies(workspaceId, token);
+    const existingNames = new Set(existing.map(o => o.displayName));
+    if (existingNames.has(displayName)) {
+      let suffix = 2;
+      while (existingNames.has(`${displayName}_${suffix}`)) suffix++;
+      displayName = `${displayName}_${suffix}`.slice(0, 89);
+    }
+  } catch {
+    // If listing fails, proceed with the original name
+  }
+
   const body: CreateOntologyRequest = {
-    displayName: sanitizeName(ontology.name),
+    displayName,
     description: (ontology.description ?? '').slice(0, 256),
     definition,
   };
+
+  // Debug: log the payload for troubleshooting
+  console.group('🔧 Fabric CREATE ontology payload');
+  console.log('displayName:', body.displayName);
+  console.log('parts count:', definition.parts.length);
+  for (const part of definition.parts) {
+    try {
+      const decoded = JSON.parse(atob(part.payload));
+      console.log(`  📄 ${part.path}:`, decoded);
+    } catch { console.log(`  📄 ${part.path}: [binary]`); }
+  }
+  console.groupEnd();
 
   const result = await fabricFetch<FabricOntologyResponse>(
     `/workspaces/${encodeURIComponent(workspaceId)}/ontologies`,
@@ -379,7 +647,7 @@ export async function createOntology(
 
   // If 202 (long-running), poll until complete
   if (result.operationId) {
-    await pollOperation(result.operationId, token);
+    await pollOperation(result.operationId, token, 60, 3000, onProgress);
     // Fetch the created ontology — the operation doesn't return it
     const ontologies = await listOntologies(workspaceId, token);
     const created = ontologies.find(o => o.displayName === body.displayName);
@@ -398,16 +666,716 @@ export async function updateOntologyDefinition(
   ontologyId: string,
   token: string,
   ontology: Ontology,
+  onProgress?: (progress: PollProgress) => void,
 ): Promise<void> {
+  validateForFabric(ontology);
+
   const { definition } = convertToFabricParts(ontology);
 
   const result = await fabricFetch<void>(
-    `/workspaces/${encodeURIComponent(workspaceId)}/ontologies/${encodeURIComponent(ontologyId)}/updateDefinition`,
+    `/workspaces/${encodeURIComponent(workspaceId)}/ontologies/${encodeURIComponent(ontologyId)}/updateDefinition?updateMetadata=true`,
     token,
     { method: 'POST', body: JSON.stringify({ definition }) },
   );
 
   if (result.operationId) {
-    await pollOperation(result.operationId, token);
+    await pollOperation(result.operationId, token, 60, 3000, onProgress);
   }
+}
+
+// ─── Data Binding Support ──────────────────────────────────────────────────
+
+export interface DataBindingConfig {
+  workspaceId: string;
+  lakehouseId: string;
+  entityIdMap: Map<string, string>;
+  propertyIdMap: Map<string, Map<string, string>>;
+  entityNameMap: Map<string, string>;
+}
+
+/**
+ * Generate DataBinding definition parts for each entity type.
+ * Maps each entity to a Lakehouse table with matching column names.
+ */
+export function generateDataBindingParts(
+  ontology: Ontology,
+  config: DataBindingConfig,
+): FabricDefinitionPart[] {
+  const parts: FabricDefinitionPart[] = [];
+
+  for (const entity of ontology.entityTypes) {
+    const fabricEntityId = config.entityIdMap.get(entity.id);
+    const propMap = config.propertyIdMap.get(entity.id);
+    const tableName = config.entityNameMap.get(entity.id);
+    if (!fabricEntityId || !propMap || !tableName) continue;
+
+    const sourceProps = entity.properties.length > 0
+      ? entity.properties
+      : [{ name: 'Id', type: 'string' as const }];
+
+    const bindingId = crypto.randomUUID();
+
+    const binding = {
+      id: bindingId,
+      dataBindingConfiguration: {
+        dataBindingType: 'NonTimeSeries',
+        propertyBindings: sourceProps.map(prop => ({
+          sourceColumnName: prop.name,
+          targetPropertyId: propMap.get(prop.name) ?? '',
+        })).filter(b => b.targetPropertyId),
+        sourceTableProperties: {
+          sourceType: 'LakehouseTable',
+          workspaceId: config.workspaceId,
+          itemId: config.lakehouseId,
+          sourceTableName: tableName,
+          sourceSchema: 'dbo',
+        },
+      },
+    };
+
+    parts.push({
+      path: `EntityTypes/${fabricEntityId}/DataBindings/${bindingId}.json`,
+      payload: toBase64(binding),
+      payloadType: 'InlineBase64',
+    });
+  }
+
+  return parts;
+}
+
+/**
+ * Find a Lakehouse in a workspace by partial name match.
+ * Retries to handle eventual consistency after ontology creation.
+ */
+export async function findLakehouse(
+  workspaceId: string,
+  token: string,
+  nameContains: string,
+  maxRetries = 10,
+  delayMs = 3000,
+): Promise<{ id: string; displayName: string } | null> {
+  for (let i = 0; i < maxRetries; i++) {
+    const { data } = await fabricFetch<{ value: { id: string; displayName: string }[] }>(
+      `/workspaces/${encodeURIComponent(workspaceId)}/lakehouses`,
+      token,
+    );
+    const lakehouses = data?.value ?? [];
+    const match = lakehouses.find(l =>
+      l.displayName.toLowerCase().includes(nameContains.toLowerCase()),
+    );
+    if (match) return match;
+    if (i < maxRetries - 1) {
+      await new Promise(resolve => setTimeout(resolve, delayMs));
+    }
+  }
+  return null;
+}
+
+// ─── GraphModel population ─────────────────────────────────────────────────
+
+type GraphPropertyType = 'STRING' | 'INT' | 'FLOAT' | 'BOOLEAN';
+
+/**
+ * Infer column schemas from sample entity instances.
+ * Column names come from EntityInstance.values keys (which become CSV headers
+ * and thus Parquet column names). Types are inferred from the first non-null value.
+ */
+function inferColumnSchemas(
+  instances: import('../data/ontology').EntityInstance[],
+): { name: string; type: GraphPropertyType }[] {
+  if (instances.length === 0) return [];
+  const columns = Object.keys(instances[0].values);
+  return columns.map(col => {
+    let type: GraphPropertyType = 'STRING';
+    for (const inst of instances) {
+      const val = inst.values[col];
+      if (val === null || val === undefined) continue;
+      if (typeof val === 'boolean') { type = 'BOOLEAN'; break; }
+      if (typeof val === 'number') {
+        type = Number.isInteger(val) ? 'INT' : 'FLOAT';
+        break;
+      }
+      // strings, Dates, and anything else → STRING (safest for dates/timestamps)
+      type = 'STRING';
+      break;
+    }
+    return { name: col, type };
+  });
+}
+
+/**
+ * Find the auto-provisioned GraphModel for a newly created ontology.
+ * Fabric creates a GraphModel alongside each ontology with a matching name.
+ */
+async function findGraphModel(
+  workspaceId: string,
+  token: string,
+  ontologyDisplayName: string,
+  maxRetries = 10,
+  delayMs = 3000,
+): Promise<{ id: string; displayName: string } | null> {
+  for (let i = 0; i < maxRetries; i++) {
+    try {
+      const { data } = await fabricFetch<{ value: { id: string; displayName: string }[] }>(
+        `/workspaces/${encodeURIComponent(workspaceId)}/graphModels`,
+        token,
+      );
+      const models = data?.value ?? [];
+      const match = models.find(m =>
+        m.displayName === ontologyDisplayName ||
+        m.displayName.toLowerCase().includes(ontologyDisplayName.toLowerCase()),
+      );
+      if (match) return match;
+    } catch { /* retry */ }
+    if (i < maxRetries - 1) {
+      await new Promise(resolve => setTimeout(resolve, delayMs));
+    }
+  }
+  return null;
+}
+
+/**
+ * Get the current GraphModel definition (needed for .platform part).
+ * getDefinition is async (202) — poll then fetch result.
+ */
+async function getGraphModelDefinition(
+  workspaceId: string,
+  graphModelId: string,
+  token: string,
+): Promise<FabricDefinitionPart[] | null> {
+  try {
+    const result = await fabricFetch<{ definition: FabricOntologyDefinition } | null>(
+      `/workspaces/${encodeURIComponent(workspaceId)}/graphModels/${encodeURIComponent(graphModelId)}/getDefinition`,
+      token,
+      { method: 'POST' },
+    );
+    if (!result.data && result.operationId) {
+      await pollOperation(result.operationId, token, 20, 3000);
+      const opResult = await fabricFetch<{ definition: FabricOntologyDefinition }>(
+        `/operations/${result.operationId}/result`,
+        token,
+      );
+      return opResult.data?.definition?.parts ?? null;
+    }
+    return result.data?.definition?.parts ?? null;
+  } catch {
+    return null;
+  }
+}
+
+// ─── Edge table generation ─────────────────────────────────────────────────
+
+interface EdgeTableMeta {
+  tableName: string;          // sanitized Delta table name
+  relationshipName: string;   // display label for the edge
+  sourceEntityName: string;   // sanitized entity name (matches node alias prefix)
+  destEntityName: string;     // sanitized entity name (matches node alias prefix)
+  sourcePkColumn: string;     // PK column in source entity table
+  destPkColumn: string;       // PK column in destination entity table
+}
+
+/**
+ * Find the identifier (PK) column for an entity type.
+ * Uses the ontology `isIdentifier` flag, falling back to the first property.
+ */
+function findPkColumn(
+  entityName: string,
+  ontology: import('../data/ontology').Ontology,
+  instances: import('../data/ontology').EntityInstance[],
+): string | null {
+  // Try ontology metadata first
+  const entityType = ontology.entityTypes.find(e => e.name === entityName);
+  if (entityType) {
+    const idProp = entityType.properties.find(p => p.isIdentifier);
+    if (idProp) return idProp.name;
+  }
+  // Fallback: first column in the instance values
+  if (instances.length > 0) {
+    const keys = Object.keys(instances[0].values);
+    if (keys.length > 0) return keys[0];
+  }
+  return null;
+}
+
+/**
+ * Generate edge tables from ontology relationships and sample entity data.
+ * Each relationship produces a two-column table (sourceId, targetId)
+ * that the GraphModel uses to draw edges between nodes.
+ */
+export function generateEdgeTables(
+  ontology: import('../data/ontology').Ontology,
+  sampleTables: Map<string, import('../data/ontology').EntityInstance[]>,
+): { edgeInstances: Map<string, import('../data/ontology').EntityInstance[]>; edgeMeta: EdgeTableMeta[] } {
+  const edgeInstances = new Map<string, import('../data/ontology').EntityInstance[]>();
+  const edgeMeta: EdgeTableMeta[] = [];
+  const entityIdToName = new Map(ontology.entityTypes.map(e => [e.id, e.name]));
+  // Collect all existing table names to prevent collisions
+  const usedTableNames = new Set([...sampleTables.keys()].map(n => sanitizeName(n)));
+
+  for (const rel of ontology.relationships) {
+    const sourceName = entityIdToName.get(rel.from);
+    const destName = entityIdToName.get(rel.to);
+    if (!sourceName || !destName) continue;
+
+    const sourceInstances = sampleTables.get(sourceName);
+    const destInstances = sampleTables.get(destName);
+    if (!sourceInstances?.length || !destInstances?.length) {
+      console.warn(`Edge "${rel.name}": skipping — no sample data for ${!sourceInstances?.length ? sourceName : destName}`);
+      continue;
+    }
+
+    const sourcePk = findPkColumn(sourceName, ontology, sourceInstances);
+    const destPk = findPkColumn(destName, ontology, destInstances);
+    if (!sourcePk || !destPk) {
+      console.warn(`Edge "${rel.name}": skipping — cannot determine PK for ${!sourcePk ? sourceName : destName}`);
+      continue;
+    }
+
+    // Build unique table name: {relName}_{source}_{dest}
+    let tableName = sanitizeName(`${rel.name}_${sourceName}_${destName}`);
+    if (usedTableNames.has(tableName)) {
+      let suffix = 2;
+      while (usedTableNames.has(`${tableName}_${suffix}`)) suffix++;
+      tableName = `${tableName}_${suffix}`;
+    }
+    usedTableNames.add(tableName);
+
+    // Generate edge rows based on cardinality
+    const sourceKeys = sourceInstances.map(i => i.values[sourcePk]);
+    const destKeys = destInstances.map(i => i.values[destPk]);
+    const rows: import('../data/ontology').EntityInstance[] = [];
+    const seen = new Set<string>(); // deduplicate edges
+
+    const addEdge = (sk: unknown, dk: unknown) => {
+      const key = `${sk}|${dk}`;
+      if (seen.has(key)) return;
+      seen.add(key);
+      rows.push({
+        id: `edge-${rows.length}`,
+        entityTypeId: tableName,
+        values: { sourceId: sk, targetId: dk },
+      });
+    };
+
+    switch (rel.cardinality) {
+      case 'one-to-many':
+        // Each destination gets one source (round-robin across sources)
+        destKeys.forEach((dk, i) => addEdge(sourceKeys[i % sourceKeys.length], dk));
+        break;
+      case 'many-to-one':
+        // Each source gets one destination (round-robin across destinations)
+        sourceKeys.forEach((sk, i) => addEdge(sk, destKeys[i % destKeys.length]));
+        break;
+      case 'one-to-one':
+        for (let i = 0; i < Math.min(sourceKeys.length, destKeys.length); i++) {
+          addEdge(sourceKeys[i], destKeys[i]);
+        }
+        break;
+      case 'many-to-many':
+        // Each source connects to 2-3 destinations (with dedup)
+        sourceKeys.forEach((sk, si) => {
+          const count = Math.min(2 + (si % 2), destKeys.length);
+          for (let j = 0; j < count; j++) {
+            addEdge(sk, destKeys[(si + j) % destKeys.length]);
+          }
+        });
+        break;
+    }
+
+    if (rows.length > 0) {
+      edgeInstances.set(tableName, rows);
+      edgeMeta.push({
+        tableName,
+        relationshipName: sanitizeName(rel.name),
+        sourceEntityName: sanitizeName(sourceName),
+        destEntityName: sanitizeName(destName),
+        sourcePkColumn: sourcePk,
+        destPkColumn: destPk,
+      });
+    }
+  }
+
+  return { edgeInstances, edgeMeta };
+}
+
+// ─── GraphModel population ─────────────────────────────────────────────────
+
+/**
+ * Populate the auto-provisioned GraphModel with node types and edge types
+ * derived from the sample data tables and ontology relationships.
+ * This makes the IQ Graph explorer show nodes AND edges immediately.
+ */
+async function populateGraphModel(
+  workspaceId: string,
+  token: string,
+  ontologyDisplayName: string,
+  lakehouseId: string,
+  sampleTables: Map<string, import('../data/ontology').EntityInstance[]>,
+  edgeMeta: EdgeTableMeta[],
+  boundTableNames: Set<string>,
+  onStatus?: (message: string) => void,
+): Promise<void> {
+  // 1. Find the auto-provisioned GraphModel
+  const graphModel = await findGraphModel(workspaceId, token, ontologyDisplayName);
+  if (!graphModel) {
+    onStatus?.('⚠ GraphModel not found — skipping graph population');
+    return;
+  }
+
+  // 2. Get the current definition for the .platform part
+  const currentParts = await getGraphModelDefinition(workspaceId, graphModel.id, token);
+  const platformPart = currentParts?.find(p => p.path === '.platform');
+  if (!platformPart) {
+    onStatus?.('⚠ Could not read GraphModel platform — skipping graph population');
+    return;
+  }
+
+  // 3. Build node definitions (only for tables that were successfully copied)
+  const basePath = `abfss://${workspaceId}@onelake.dfs.fabric.microsoft.com/${lakehouseId}/Tables/dbo`;
+
+  const nodeTypes: unknown[] = [];
+  const dataSources: unknown[] = [];
+  const nodeTables: unknown[] = [];
+  const nodeAliases = new Set<string>(); // track which node aliases exist
+
+  for (const [entityName, instances] of sampleTables) {
+    const tableName = sanitizeName(entityName);
+    if (!boundTableNames.has(tableName)) continue; // only bound tables
+    const columns = inferColumnSchemas(instances);
+    if (columns.length === 0) continue;
+
+    const pk = columns[0].name;
+    const alias = `${tableName}_node`;
+    nodeAliases.add(alias);
+
+    nodeTypes.push({
+      alias,
+      labels: [tableName],
+      primaryKeyProperties: [pk],
+      properties: columns.map(c => ({ name: c.name, type: c.type })),
+    });
+
+    dataSources.push({
+      name: `${tableName}_ds`,
+      type: 'DeltaTable',
+      properties: { path: `${basePath}/${tableName}` },
+    });
+
+    nodeTables.push({
+      id: `${tableName}_nt`,
+      nodeTypeAlias: alias,
+      dataSourceName: `${tableName}_ds`,
+      propertyMappings: columns.map(c => ({
+        propertyName: c.name,
+        sourceColumn: c.name,
+      })),
+    });
+  }
+
+  if (nodeTypes.length === 0) return;
+
+  // 4. Build edge definitions (only for edges whose table + both endpoints exist)
+  const edgeTypes: unknown[] = [];
+  const edgeTables: unknown[] = [];
+  let skippedEdges = 0;
+
+  for (const edge of edgeMeta) {
+    if (!boundTableNames.has(edge.tableName)) { skippedEdges++; continue; }
+    const srcAlias = `${edge.sourceEntityName}_node`;
+    const dstAlias = `${edge.destEntityName}_node`;
+    if (!nodeAliases.has(srcAlias) || !nodeAliases.has(dstAlias)) { skippedEdges++; continue; }
+
+    const edgeAlias = `${edge.tableName}_edge`;
+
+    // Fabric schema: sourceNodeType/destinationNodeType are objects with { alias }
+    edgeTypes.push({
+      alias: edgeAlias,
+      labels: [edge.relationshipName],
+      sourceNodeType: { alias: srcAlias },
+      destinationNodeType: { alias: dstAlias },
+      properties: [],
+    });
+
+    dataSources.push({
+      name: `${edge.tableName}_ds`,
+      type: 'DeltaTable',
+      properties: { path: `${basePath}/${edge.tableName}` },
+    });
+
+    // Fabric schema: key columns are String[] (column names in the edge table)
+    edgeTables.push({
+      id: `${edge.tableName}_et`,
+      edgeTypeAlias: edgeAlias,
+      dataSourceName: `${edge.tableName}_ds`,
+      sourceNodeKeyColumns: ['sourceId'],
+      destinationNodeKeyColumns: ['targetId'],
+      propertyMappings: [],
+    });
+  }
+
+  if (skippedEdges > 0) {
+    console.warn(`GraphModel: skipped ${skippedEdges} edge(s) — missing tables or endpoint nodes`);
+  }
+
+  // 5. Encode all definition parts
+  const parts: FabricDefinitionPart[] = [
+    {
+      path: 'graphType.json',
+      payload: toBase64({ nodeTypes, edgeTypes }),
+      payloadType: 'InlineBase64',
+    },
+    {
+      path: 'dataSources.json',
+      payload: toBase64({ dataSources }),
+      payloadType: 'InlineBase64',
+    },
+    {
+      path: 'graphDefinition.json',
+      payload: toBase64({ nodeTables, edgeTables }),
+      payloadType: 'InlineBase64',
+    },
+    {
+      path: 'stylingConfiguration.json',
+      payload: toBase64({
+        modelLayout: {
+          positions: {},
+          styles: {},
+          pan: { x: 0, y: 0 },
+          zoomLevel: 1.0,
+        },
+        visualFormat: null,
+        scenario: 'Ontology',
+      }),
+      payloadType: 'InlineBase64',
+    },
+    platformPart,
+  ];
+
+  // 6. Push the definition
+  const updateResult = await fabricFetch<void>(
+    `/workspaces/${encodeURIComponent(workspaceId)}/graphModels/${encodeURIComponent(graphModel.id)}/updateDefinition?updateMetadata=true`,
+    token,
+    { method: 'POST', body: JSON.stringify({ definition: { parts } }) },
+  );
+
+  if (updateResult.operationId) {
+    onStatus?.('Applying graph model definition…');
+    await pollOperation(updateResult.operationId, token, 30, 3000);
+  }
+
+  onStatus?.(`✓ Graph populated with ${nodeTypes.length} node types and ${edgeTypes.length} edge types`);
+}
+
+/**
+ * Full push with sample data: create ontology → upload data → bind → populate graph.
+ * Returns the created ontology response.
+ */
+export async function createOntologyWithData(
+  workspaceId: string,
+  fabricToken: string,
+  oneLakeToken: string,
+  ontology: Ontology,
+  sampleTables: Map<string, import('../data/ontology').EntityInstance[]>,
+  onProgress?: (progress: PollProgress) => void,
+  onStatus?: (message: string) => void,
+  options?: { includeDataAgent?: boolean },
+): Promise<FabricOntologyResponse> {
+  // Step 1: Validate, convert, and generate edge tables
+  validateForFabric(ontology);
+  const conversion = convertToFabricParts(ontology);
+  const { edgeInstances, edgeMeta } = generateEdgeTables(ontology, sampleTables);
+
+  // Merge entity + edge tables for the upload pipeline
+  const allTables = new Map([...sampleTables, ...edgeInstances]);
+
+  // Step 2: Create the ontology (schema only)
+  onStatus?.('Creating ontology schema…');
+  let displayName = sanitizeItemName(ontology.name);
+  try {
+    const existing = await listOntologies(workspaceId, fabricToken);
+    const existingNames = new Set(existing.map(o => o.displayName));
+    if (existingNames.has(displayName)) {
+      let suffix = 2;
+      while (existingNames.has(`${displayName}_${suffix}`)) suffix++;
+      displayName = `${displayName}_${suffix}`.slice(0, 89);
+    }
+  } catch { /* proceed with original name */ }
+
+  const body: CreateOntologyRequest = {
+    displayName,
+    description: (ontology.description ?? '').slice(0, 256),
+    definition: conversion.definition,
+  };
+
+  const result = await fabricFetch<FabricOntologyResponse>(
+    `/workspaces/${encodeURIComponent(workspaceId)}/ontologies`,
+    fabricToken,
+    { method: 'POST', body: JSON.stringify(body) },
+  );
+
+  if (result.operationId) {
+    onProgress?.({ attempt: 0, maxAttempts: 60, status: 'Creating ontology…' });
+    await pollOperation(result.operationId, fabricToken, 60, 3000, onProgress);
+  }
+
+  const ontologies = await listOntologies(workspaceId, fabricToken);
+  const created = ontologies.find(o => o.displayName === displayName);
+  if (!created) {
+    throw new FabricApiError('Ontology created but not found in workspace', 404);
+  }
+
+  // Step 3: Find the auto-provisioned Lakehouse for this ontology.
+  // Fabric requires data bindings to reference the ontology's own Lakehouse.
+  onStatus?.('Waiting for auto-provisioned Lakehouse…');
+  const autoLh = await findLakehouse(workspaceId, fabricToken, created.id.replace(/-/g, ''));
+  if (!autoLh) {
+    onStatus?.('⚠ Could not find auto-provisioned Lakehouse — ontology created without sample data');
+    return created;
+  }
+
+  // Step 4: Create a temporary plain Lakehouse for CSV→Delta conversion.
+  // The auto-provisioned LH has schemas enabled and the Load Table API
+  // doesn't support it, so we convert in a temp LH then copy the Delta
+  // files over and delete the temp LH.
+  onStatus?.('Creating temporary Lakehouse…');
+  const { createLakehouse, uploadEntityTable, copyDeltaTable, deleteLakehouse } = await import('./fabricLakehouse');
+  const tmpLhName = `${displayName}_tmp`.slice(0, 89);
+  let tmpLakehouse: { id: string; displayName: string };
+  try {
+    tmpLakehouse = await createLakehouse(workspaceId, fabricToken, tmpLhName, 'Temporary — CSV to Delta conversion');
+  } catch (err) {
+    console.warn('Failed to create temp Lakehouse:', err);
+    onStatus?.('⚠ Could not create temp Lakehouse — ontology created without sample data');
+    return created;
+  }
+
+  // Step 5: Upload sample data + edge tables to the temp Lakehouse and convert to Delta
+  const tableEntries = Array.from(allTables.entries());
+  const loadedTableNames: string[] = [];
+  for (let i = 0; i < tableEntries.length; i++) {
+    const [entityName, instances] = tableEntries[i];
+    const tableName = sanitizeName(entityName);
+    onStatus?.(`Uploading ${entityName} (${i + 1}/${tableEntries.length})…`);
+    try {
+      await uploadEntityTable(workspaceId, tmpLakehouse.id, oneLakeToken, tableName, instances, fabricToken);
+      loadedTableNames.push(tableName);
+    } catch (err) {
+      console.warn(`Failed to upload table ${tableName}:`, err);
+    }
+  }
+
+  if (loadedTableNames.length === 0 && tableEntries.length > 0) {
+    onStatus?.('⚠ All table uploads failed — ontology created without sample data');
+    return created;
+  }
+
+  // Step 6: Copy Delta table files from temp LH into the auto-provisioned LH.
+  // Fabric auto-registers Delta tables written to Tables/dbo/ in the catalog.
+  onStatus?.('Copying tables to ontology Lakehouse…');
+  const boundTableNames: string[] = [];
+  for (const tableName of loadedTableNames) {
+    try {
+      await copyDeltaTable(workspaceId, tmpLakehouse.id, autoLh.id, tableName, oneLakeToken);
+      boundTableNames.push(tableName);
+    } catch (err) {
+      console.warn(`Failed to copy ${tableName}:`, err);
+    }
+  }
+
+  // Step 6b: Delete the temporary Lakehouse (best-effort cleanup)
+  onStatus?.('Cleaning up temporary Lakehouse…');
+  const deleted = await deleteLakehouse(workspaceId, tmpLakehouse.id, fabricToken);
+  if (!deleted) {
+    console.warn(`Could not delete temp Lakehouse ${tmpLhName} — manual cleanup needed`);
+  }
+
+  if (boundTableNames.length === 0) {
+    onStatus?.('⚠ Could not copy tables — ontology created without data bindings');
+    return created;
+  }
+
+  // Step 7: Create data bindings only for tables that have working shortcuts
+  // (Fabric requires bindings reference the ontology's own Lakehouse)
+  if (boundTableNames.length < loadedTableNames.length) {
+    onStatus?.(`Linked ${boundTableNames.length}/${loadedTableNames.length} tables. Creating data bindings…`);
+  } else {
+    onStatus?.('Creating data bindings…');
+  }
+
+  // Only bind entities whose tables were successfully copied
+  const boundTableSet = new Set(boundTableNames);
+  const bindingParts = generateDataBindingParts(ontology, {
+    workspaceId,
+    lakehouseId: autoLh.id,
+    entityIdMap: conversion.entityIdMap,
+    propertyIdMap: conversion.propertyIdMap,
+    entityNameMap: conversion.entityNameMap,
+  }).filter(part => {
+    // Extract table name from binding path to check if it has a shortcut
+    const payload = JSON.parse(atob(part.payload));
+    const tableName = payload?.dataBindingConfiguration?.sourceTableProperties?.sourceTableName;
+    return !tableName || boundTableSet.has(tableName);
+  });
+
+  if (bindingParts.length > 0) {
+    // Fetch the current definition from Fabric (it may have added $schema fields)
+    // and merge our binding parts with it, rather than using our original parts
+    const currentDefParts = await getDefinition(workspaceId, created.id, fabricToken);
+    const defParts = currentDefParts ?? conversion.definition.parts;
+    const fullDefinition: FabricOntologyDefinition = {
+      parts: [...defParts, ...bindingParts],
+    };
+
+    const updateResult = await fabricFetch<void>(
+      `/workspaces/${encodeURIComponent(workspaceId)}/ontologies/${encodeURIComponent(created.id)}/updateDefinition?updateMetadata=true`,
+      fabricToken,
+      { method: 'POST', body: JSON.stringify({ definition: fullDefinition }) },
+    );
+
+    if (updateResult.operationId) {
+      onStatus?.('Applying data bindings…');
+      await pollOperation(updateResult.operationId, fabricToken, 60, 3000, onProgress);
+    }
+  }
+
+  // Step 8: Populate the auto-provisioned GraphModel with node types + edge types
+  // derived from actual table schemas so the IQ Graph view shows data AND relationships.
+  onStatus?.('Populating graph model…');
+  try {
+    await populateGraphModel(
+      workspaceId,
+      fabricToken,
+      displayName,
+      autoLh.id,
+      sampleTables,
+      edgeMeta,
+      boundTableSet,
+      onStatus,
+    );
+  } catch (err) {
+    console.warn('GraphModel population failed (non-fatal):', err);
+    onStatus?.('⚠ Graph model population failed — ontology and data are still available');
+  }
+
+  // Step 9: Create a Data Agent connected to the ontology (optional)
+  if (options?.includeDataAgent) {
+    onStatus?.('Creating Data Agent…');
+    try {
+      const { createDataAgent } = await import('./fabricDataAgent');
+      await createDataAgent(
+        workspaceId,
+        fabricToken,
+        displayName,
+        created.id,
+        ontology,
+        onStatus,
+      );
+    } catch (err) {
+      console.warn('Data Agent creation failed (non-fatal):', err);
+      onStatus?.('⚠ Data Agent creation failed — ontology and data are still available');
+    }
+  }
+
+  onStatus?.('✓ Ontology ready with sample data and graph');
+  return created;
 }

--- a/src/lib/fabricDataAgent.test.ts
+++ b/src/lib/fabricDataAgent.test.ts
@@ -1,0 +1,274 @@
+import { describe, it, expect } from 'vitest';
+import { generateAIInstructions, generateFewShots, buildDataAgentParts } from './fabricDataAgent';
+import type { Ontology } from '../data/ontology';
+
+// ─── Test Ontology ───────────────────────────────────────────────────────────
+
+const testOntology: Ontology = {
+  name: 'Wind Power System',
+  description: 'Models a wind farm with turbines, sensors, and maintenance workflows.',
+  entityTypes: [
+    {
+      id: 'windfarm',
+      name: 'WindFarm',
+      description: 'An offshore or onshore wind farm installation',
+      properties: [
+        { name: 'farmId', type: 'string', isIdentifier: true },
+        { name: 'name', type: 'string' },
+        { name: 'country', type: 'string' },
+        { name: 'capacityMW', type: 'integer' },
+      ],
+      icon: '🌬️',
+      color: '#4CAF50',
+    },
+    {
+      id: 'turbine',
+      name: 'Turbine',
+      description: 'A wind turbine that generates electricity',
+      properties: [
+        { name: 'turbineId', type: 'string', isIdentifier: true },
+        { name: 'model', type: 'string' },
+        { name: 'ratedPowerMW', type: 'double' },
+        { name: 'status', type: 'string' },
+      ],
+      icon: '⚡',
+      color: '#2196F3',
+    },
+    {
+      id: 'sensor',
+      name: 'SensorSignal',
+      description: 'A sensor reading from a turbine component',
+      properties: [
+        { name: 'signalId', type: 'string', isIdentifier: true },
+        { name: 'signalType', type: 'string' },
+        { name: 'value', type: 'double' },
+      ],
+      icon: '📡',
+      color: '#FF9800',
+    },
+  ],
+  relationships: [
+    {
+      id: 'farm-has-turbines',
+      name: 'HasTurbines',
+      from: 'WindFarm',
+      to: 'Turbine',
+      cardinality: 'one-to-many',
+      description: 'A wind farm contains multiple turbines',
+    },
+    {
+      id: 'turbine-has-signals',
+      name: 'EmitsSignals',
+      from: 'Turbine',
+      to: 'SensorSignal',
+      cardinality: 'one-to-many',
+    },
+  ],
+};
+
+// ─── AI Instructions Tests ───────────────────────────────────────────────────
+
+describe('generateAIInstructions', () => {
+  it('includes ontology name', () => {
+    const result = generateAIInstructions(testOntology);
+    expect(result).toContain('Wind Power System');
+  });
+
+  it('includes domain description', () => {
+    const result = generateAIInstructions(testOntology);
+    expect(result).toContain('wind farm with turbines');
+  });
+
+  it('lists all entity types', () => {
+    const result = generateAIInstructions(testOntology);
+    expect(result).toContain('WindFarm');
+    expect(result).toContain('Turbine');
+    expect(result).toContain('SensorSignal');
+  });
+
+  it('includes entity descriptions', () => {
+    const result = generateAIInstructions(testOntology);
+    expect(result).toContain('offshore or onshore wind farm');
+    expect(result).toContain('generates electricity');
+  });
+
+  it('lists properties with types and PK markers', () => {
+    const result = generateAIInstructions(testOntology);
+    expect(result).toContain('farmId (string [PK])');
+    expect(result).toContain('capacityMW (integer)');
+  });
+
+  it('includes entity count', () => {
+    const result = generateAIInstructions(testOntology);
+    expect(result).toContain('ENTITY TYPES (3 total)');
+  });
+
+  it('lists relationships with cardinality', () => {
+    const result = generateAIInstructions(testOntology);
+    expect(result).toContain('HasTurbines: WindFarm → Turbine (1:N)');
+    expect(result).toContain('EmitsSignals: Turbine → SensorSignal (1:N)');
+  });
+
+  it('includes relationship descriptions', () => {
+    const result = generateAIInstructions(testOntology);
+    expect(result).toContain('contains multiple turbines');
+  });
+
+  it('includes GQL query guidelines', () => {
+    const result = generateAIInstructions(testOntology);
+    expect(result).toContain('MATCH patterns');
+    expect(result).toContain('Support group by in GQL');
+  });
+
+  it('handles ontology without description', () => {
+    const noDesc: Ontology = { ...testOntology, description: '' };
+    const result = generateAIInstructions(noDesc);
+    expect(result).not.toContain('DOMAIN OVERVIEW');
+    expect(result).toContain('WindFarm');
+  });
+
+  it('handles ontology without relationships', () => {
+    const noRels: Ontology = { ...testOntology, relationships: [] };
+    const result = generateAIInstructions(noRels);
+    expect(result).not.toContain('RELATIONSHIPS');
+    expect(result).toContain('WindFarm');
+  });
+});
+
+// ─── Few-Shot Tests ──────────────────────────────────────────────────────────
+
+describe('generateFewShots', () => {
+  it('generates shots for entity types', () => {
+    const shots = generateFewShots(testOntology);
+    expect(shots.length).toBeGreaterThan(0);
+
+    const listShot = shots.find(s => s.question.includes('List all WindFarm'));
+    expect(listShot).toBeDefined();
+    expect(listShot!.query).toContain('MATCH (n:WindFarm)');
+  });
+
+  it('generates count examples', () => {
+    const shots = generateFewShots(testOntology);
+    const countShot = shots.find(s => s.question.includes('How many'));
+    expect(countShot).toBeDefined();
+    expect(countShot!.query).toContain('COUNT');
+  });
+
+  it('generates relationship traversal examples', () => {
+    const shots = generateFewShots(testOntology);
+    const relShot = shots.find(s => s.query.includes('HasTurbines'));
+    expect(relShot).toBeDefined();
+    expect(relShot!.query).toContain('MATCH');
+    expect(relShot!.query).toContain('WindFarm');
+    expect(relShot!.query).toContain('Turbine');
+  });
+
+  it('generates unique IDs for all shots', () => {
+    const shots = generateFewShots(testOntology);
+    const ids = shots.map(s => s.id);
+    const uniqueIds = new Set(ids);
+    expect(uniqueIds.size).toBe(ids.length);
+  });
+
+  it('generates property filter examples for string props', () => {
+    const shots = generateFewShots(testOntology);
+    // WindFarm has 'name' (string, not PK) and 'country' (string)
+    const filterShot = shots.find(s => s.question.includes('name') || s.question.includes('country'));
+    expect(filterShot).toBeDefined();
+  });
+});
+
+// ─── Definition Parts Tests ──────────────────────────────────────────────────
+
+describe('buildDataAgentParts', () => {
+  const ontologyId = 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee';
+  const workspaceId = '11111111-2222-3333-4444-555555555555';
+
+  it('produces 8 definition parts', () => {
+    const parts = buildDataAgentParts(ontologyId, workspaceId, testOntology);
+    expect(parts).toHaveLength(8);
+  });
+
+  it('includes data_agent.json with correct schema', () => {
+    const parts = buildDataAgentParts(ontologyId, workspaceId, testOntology);
+    const agentPart = parts.find(p => p.path === 'Files/Config/data_agent.json');
+    expect(agentPart).toBeDefined();
+    const decoded = JSON.parse(atob(agentPart!.payload));
+    expect(decoded.$schema).toBe('2.1.0');
+  });
+
+  it('includes draft stage_config with AI instructions', () => {
+    const parts = buildDataAgentParts(ontologyId, workspaceId, testOntology);
+    const configPart = parts.find(p => p.path === 'Files/Config/draft/stage_config.json');
+    expect(configPart).toBeDefined();
+    const decoded = JSON.parse(atob(configPart!.payload));
+    expect(decoded.$schema).toBe('1.0.0');
+    expect(decoded.aiInstructions).toContain('Wind Power System');
+    expect(decoded.aiInstructions).toContain('WindFarm');
+  });
+
+  it('includes datasource.json referencing ontology', () => {
+    const parts = buildDataAgentParts(ontologyId, workspaceId, testOntology);
+    const dsPart = parts.find(p => p.path.includes('datasource.json') && p.path.includes('draft'));
+    expect(dsPart).toBeDefined();
+    const decoded = JSON.parse(atob(dsPart!.payload));
+    expect(decoded.artifactId).toBe(ontologyId);
+    expect(decoded.workspaceId).toBe(workspaceId);
+    expect(decoded.type).toBe('ontology');
+    expect(decoded.displayName).toBe('Wind Power System');
+  });
+
+  it('includes fewshots.json with valid examples', () => {
+    const parts = buildDataAgentParts(ontologyId, workspaceId, testOntology);
+    const fsPart = parts.find(p => p.path.includes('fewshots.json') && p.path.includes('draft'));
+    expect(fsPart).toBeDefined();
+    const decoded = JSON.parse(atob(fsPart!.payload));
+    expect(decoded.$schema).toBe('1.0.0');
+    expect(decoded.fewShots.length).toBeGreaterThan(0);
+    // Each shot has id, question, query
+    for (const shot of decoded.fewShots) {
+      expect(shot.id).toBeTruthy();
+      expect(shot.question).toBeTruthy();
+      expect(shot.query).toBeTruthy();
+    }
+  });
+
+  it('includes published copies matching draft', () => {
+    const parts = buildDataAgentParts(ontologyId, workspaceId, testOntology);
+    const draftConfig = parts.find(p => p.path === 'Files/Config/draft/stage_config.json');
+    const pubConfig = parts.find(p => p.path === 'Files/Config/published/stage_config.json');
+    expect(draftConfig).toBeDefined();
+    expect(pubConfig).toBeDefined();
+    expect(draftConfig!.payload).toBe(pubConfig!.payload);
+  });
+
+  it('includes publish_info.json', () => {
+    const parts = buildDataAgentParts(ontologyId, workspaceId, testOntology);
+    const piPart = parts.find(p => p.path === 'Files/Config/publish_info.json');
+    expect(piPart).toBeDefined();
+    const decoded = JSON.parse(atob(piPart!.payload));
+    expect(decoded.$schema).toBe('1.0.0');
+    expect(decoded.description).toContain('Wind Power System');
+  });
+
+  it('all parts use InlineBase64 payloadType', () => {
+    const parts = buildDataAgentParts(ontologyId, workspaceId, testOntology);
+    for (const part of parts) {
+      expect(part.payloadType).toBe('InlineBase64');
+    }
+  });
+
+  it('datasource folder name is sanitized', () => {
+    const weirdOntology: Ontology = {
+      ...testOntology,
+      name: 'My Weird Ontology! (v2.0)',
+    };
+    const parts = buildDataAgentParts(ontologyId, workspaceId, weirdOntology);
+    const dsPart = parts.find(p => p.path.includes('datasource.json') && p.path.includes('draft'));
+    expect(dsPart).toBeDefined();
+    // Should not contain special chars
+    expect(dsPart!.path).not.toContain('!');
+    expect(dsPart!.path).not.toContain('(');
+    expect(dsPart!.path).toMatch(/ontology-[a-zA-Z0-9_-]+/);
+  });
+});

--- a/src/lib/fabricDataAgent.ts
+++ b/src/lib/fabricDataAgent.ts
@@ -1,0 +1,336 @@
+/**
+ * Fabric Data Agent — creates a Data Agent connected to a pushed ontology
+ * so users can query their data with natural language immediately.
+ *
+ * API Reference:
+ *   https://learn.microsoft.com/en-us/rest/api/fabric/dataagent/items/create-data-agent
+ *   https://learn.microsoft.com/en-us/rest/api/fabric/articles/item-management/definitions/data-agent-definition
+ */
+
+import type { Ontology, Relationship } from '../data/ontology';
+
+// ─── Schema constants ────────────────────────────────────────────────────────
+
+const DATA_AGENT_SCHEMA = '2.1.0';
+const STAGE_CONFIG_SCHEMA = '1.0.0';
+const DATASOURCE_SCHEMA = '1.0.0';
+const FEWSHOTS_SCHEMA = '1.0.0';
+const PUBLISH_INFO_SCHEMA = '1.0.0';
+
+// ─── Types ───────────────────────────────────────────────────────────────────
+
+interface DefinitionPart {
+  path: string;
+  payload: string;          // base64-encoded JSON
+  payloadType: 'InlineBase64';
+}
+
+// ─── AI Instructions Generation ──────────────────────────────────────────────
+
+function describeCardinality(c: Relationship['cardinality']): string {
+  switch (c) {
+    case 'one-to-one': return '1:1';
+    case 'one-to-many': return '1:N';
+    case 'many-to-one': return 'N:1';
+    case 'many-to-many': return 'N:N';
+    default: return c;
+  }
+}
+
+/**
+ * Generate rich AI instructions from the ontology metadata.
+ * These teach the Data Agent about the domain, entity types, relationships,
+ * and how to write correct GQL queries.
+ */
+export function generateAIInstructions(ontology: Ontology): string {
+  const lines: string[] = [];
+
+  lines.push(`You are an expert data assistant for the "${ontology.name}" ontology.`);
+  lines.push('');
+
+  // Domain overview
+  if (ontology.description) {
+    lines.push('DOMAIN OVERVIEW:');
+    lines.push(ontology.description);
+    lines.push('');
+  }
+
+  // Entity types with properties
+  lines.push(`ENTITY TYPES (${ontology.entityTypes.length} total):`);
+  for (const entity of ontology.entityTypes) {
+    const props = entity.properties.map(p => {
+      const suffix = p.isIdentifier ? ' [PK]' : '';
+      return `${p.name} (${p.type}${suffix})`;
+    }).join(', ');
+
+    const desc = entity.description ? ` — ${entity.description}` : '';
+    lines.push(`- ${entity.name}${desc}`);
+    if (props) {
+      lines.push(`  Properties: ${props}`);
+    }
+  }
+  lines.push('');
+
+  // Relationships
+  if (ontology.relationships.length > 0) {
+    lines.push(`RELATIONSHIPS (${ontology.relationships.length} total):`);
+    for (const rel of ontology.relationships) {
+      const card = describeCardinality(rel.cardinality);
+      const desc = rel.description ? ` — ${rel.description}` : '';
+      lines.push(`- ${rel.name}: ${rel.from} → ${rel.to} (${card})${desc}`);
+    }
+    lines.push('');
+  }
+
+  // Query guidelines
+  lines.push('QUERY GUIDELINES:');
+  lines.push('- Use MATCH patterns to traverse the graph');
+  lines.push('- Node labels match entity type names exactly');
+  lines.push('- Edge labels match relationship names exactly');
+  lines.push('- Always return meaningful properties, not just IDs');
+  lines.push('- Support group by in GQL');
+  lines.push('- When counting or aggregating, use COUNT(), SUM(), AVG() etc.');
+  lines.push('- For filtering, use WHERE clauses with property comparisons');
+
+  return lines.join('\n');
+}
+
+// ─── Few-Shot Generation ─────────────────────────────────────────────────────
+
+function uuid(): string {
+  return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, c => {
+    const r = Math.random() * 16 | 0;
+    return (c === 'x' ? r : (r & 0x3 | 0x8)).toString(16);
+  });
+}
+
+/**
+ * Generate few-shot NL→GQL examples from the ontology schema.
+ * These help the Data Agent understand the expected query patterns.
+ */
+export function generateFewShots(ontology: Ontology): Array<{ id: string; question: string; query: string }> {
+  const shots: Array<{ id: string; question: string; query: string }> = [];
+
+  // For each entity type, add a "list" and "count" example
+  for (const entity of ontology.entityTypes.slice(0, 5)) {
+    const label = entity.name;
+    const pk = entity.properties.find(p => p.isIdentifier)?.name ?? entity.properties[0]?.name;
+
+    // List example
+    shots.push({
+      id: uuid(),
+      question: `List all ${label} records`,
+      query: `MATCH (n:${label}) RETURN n LIMIT 10`,
+    });
+
+    // Count example
+    shots.push({
+      id: uuid(),
+      question: `How many ${label} entries are there?`,
+      query: `MATCH (n:${label}) RETURN COUNT(n) AS total`,
+    });
+
+    // Property filter example (if there's a meaningful property beyond PK)
+    const filterProp = entity.properties.find(p => !p.isIdentifier && p.type === 'string');
+    if (filterProp && pk) {
+      shots.push({
+        id: uuid(),
+        question: `Show ${label} with their ${filterProp.name}`,
+        query: `MATCH (n:${label}) RETURN n.${pk}, n.${filterProp.name} LIMIT 20`,
+      });
+    }
+  }
+
+  // For relationships, add traversal examples
+  for (const rel of ontology.relationships.slice(0, 3)) {
+    shots.push({
+      id: uuid(),
+      question: `Which ${rel.from} is connected to ${rel.to}?`,
+      query: `MATCH (a:${rel.from})-[r:${rel.name}]->(b:${rel.to}) RETURN a, r, b LIMIT 10`,
+    });
+  }
+
+  return shots;
+}
+
+// ─── Definition Parts Builder ────────────────────────────────────────────────
+
+function toBase64(obj: unknown): string {
+  const json = JSON.stringify(obj, null, 2);
+  // TextEncoder → Uint8Array → binary string → btoa (handles non-ASCII)
+  const bytes = new TextEncoder().encode(json);
+  let binary = '';
+  for (const b of bytes) {
+    binary += String.fromCharCode(b);
+  }
+  return btoa(binary);
+}
+
+/**
+ * Build all definition parts for a Data Agent that connects to an ontology.
+ */
+export function buildDataAgentParts(
+  ontologyId: string,
+  workspaceId: string,
+  ontology: Ontology,
+): DefinitionPart[] {
+  const agentInstructions = generateAIInstructions(ontology);
+  const fewShots = generateFewShots(ontology);
+  const safeName = ontology.name.replace(/[^a-zA-Z0-9_-]/g, '_').slice(0, 60);
+
+  // data_agent.json — top-level config
+  const dataAgentConfig = {
+    $schema: DATA_AGENT_SCHEMA,
+  };
+
+  // stage_config.json — AI instructions
+  const stageConfig = {
+    $schema: STAGE_CONFIG_SCHEMA,
+    aiInstructions: agentInstructions,
+  };
+
+  // datasource.json — reference the ontology
+  const datasource = {
+    $schema: DATASOURCE_SCHEMA,
+    artifactId: ontologyId,
+    workspaceId,
+    displayName: ontology.name,
+    type: 'ontology',
+    dataSourceInstructions: `This ontology models ${ontology.description || ontology.name}. Use it to answer questions about ${ontology.entityTypes.map(e => e.name).join(', ')}.`,
+  };
+
+  // fewshots.json — pre-seeded NL→GQL examples
+  const fewshotsConfig = {
+    $schema: FEWSHOTS_SCHEMA,
+    fewShots,
+  };
+
+  // publish_info.json — marks agent as published
+  const publishInfo = {
+    $schema: PUBLISH_INFO_SCHEMA,
+    description: `Data Agent for ${ontology.name} ontology — auto-generated`,
+  };
+
+  const dsFolder = `ontology-${safeName}`;
+  const parts: DefinitionPart[] = [
+    // Required top-level config
+    { path: 'Files/Config/data_agent.json', payload: toBase64(dataAgentConfig), payloadType: 'InlineBase64' },
+
+    // Draft stage config + data source
+    { path: 'Files/Config/draft/stage_config.json', payload: toBase64(stageConfig), payloadType: 'InlineBase64' },
+    { path: `Files/Config/draft/${dsFolder}/datasource.json`, payload: toBase64(datasource), payloadType: 'InlineBase64' },
+    { path: `Files/Config/draft/${dsFolder}/fewshots.json`, payload: toBase64(fewshotsConfig), payloadType: 'InlineBase64' },
+
+    // Published copies (same content — makes agent immediately queryable)
+    { path: 'Files/Config/published/stage_config.json', payload: toBase64(stageConfig), payloadType: 'InlineBase64' },
+    { path: `Files/Config/published/${dsFolder}/datasource.json`, payload: toBase64(datasource), payloadType: 'InlineBase64' },
+    { path: `Files/Config/published/${dsFolder}/fewshots.json`, payload: toBase64(fewshotsConfig), payloadType: 'InlineBase64' },
+
+    // Publish info
+    { path: 'Files/Config/publish_info.json', payload: toBase64(publishInfo), payloadType: 'InlineBase64' },
+  ];
+
+  return parts;
+}
+
+// ─── Data Agent Creation ─────────────────────────────────────────────────────
+
+const FABRIC_API_BASE = 'https://api.fabric.microsoft.com/v1';
+
+interface DataAgentResponse {
+  id: string;
+  displayName: string;
+  workspaceId: string;
+  type: string;
+  description?: string;
+}
+
+/**
+ * Create a Fabric Data Agent connected to the given ontology.
+ * Returns the agent ID or null if creation fails.
+ */
+export async function createDataAgent(
+  workspaceId: string,
+  token: string,
+  ontologyName: string,
+  ontologyId: string,
+  ontology: Ontology,
+  onStatus?: (message: string) => void,
+): Promise<string | null> {
+  const parts = buildDataAgentParts(ontologyId, workspaceId, ontology);
+
+  const safeName = ontologyName.replace(/[^a-zA-Z0-9_ -]/g, '').slice(0, 80);
+  const displayName = `${safeName} Agent`;
+  const description = `Natural language data agent for ${ontologyName} — auto-generated by Ontology Playground`;
+
+  onStatus?.('Creating Data Agent…');
+
+  const res = await fetch(`${FABRIC_API_BASE}/workspaces/${encodeURIComponent(workspaceId)}/dataAgents`, {
+    method: 'POST',
+    headers: {
+      'Authorization': `Bearer ${token}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      displayName,
+      description: description.slice(0, 256),
+      definition: { parts },
+    }),
+  });
+
+  // 201 = created, 202 = async provisioning
+  if (res.status === 201) {
+    const data = await res.json() as DataAgentResponse;
+    onStatus?.(`✓ Data Agent "${displayName}" created`);
+    return data.id;
+  }
+
+  if (res.status === 202) {
+    const opId = res.headers.get('x-ms-operation-id');
+    if (opId) {
+      onStatus?.('Data Agent provisioning…');
+      // Poll for completion
+      for (let i = 0; i < 30; i++) {
+        await new Promise(r => setTimeout(r, 3000));
+        const pollRes = await fetch(`${FABRIC_API_BASE}/operations/${opId}`, {
+          headers: { 'Authorization': `Bearer ${token}` },
+        });
+        if (pollRes.ok) {
+          const pollData = await pollRes.json();
+          if (pollData.status === 'Succeeded') {
+            onStatus?.(`✓ Data Agent "${displayName}" created`);
+            // Try to find the agent by listing
+            try {
+              const listRes = await fetch(`${FABRIC_API_BASE}/workspaces/${encodeURIComponent(workspaceId)}/dataAgents`, {
+                headers: { 'Authorization': `Bearer ${token}` },
+              });
+              if (listRes.ok) {
+                const listData = await listRes.json();
+                const agents = listData.value ?? [];
+                const found = agents.find((a: DataAgentResponse) => a.displayName === displayName);
+                if (found) return found.id;
+              }
+            } catch { /* ok */ }
+            return null;
+          }
+          if (pollData.status === 'Failed') {
+            const errMsg = pollData.error?.message ?? 'Unknown error';
+            onStatus?.(`⚠ Data Agent creation failed: ${errMsg}`);
+            return null;
+          }
+        }
+      }
+      onStatus?.('⚠ Data Agent creation timed out');
+    }
+    return null;
+  }
+
+  // Error handling
+  let errMsg = `${res.status} ${res.statusText}`;
+  try {
+    const body = await res.json();
+    if (body.message) errMsg = body.message;
+  } catch { /* use default */ }
+  onStatus?.(`⚠ Data Agent creation failed: ${errMsg}`);
+  return null;
+}

--- a/src/lib/fabricDeployPipeline.test.ts
+++ b/src/lib/fabricDeployPipeline.test.ts
@@ -1,0 +1,299 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('./msalAuth', () => ({
+  acquireFabricToken: vi.fn(),
+}));
+vi.mock('./fabric', () => ({
+  createOntology: vi.fn(),
+}));
+vi.mock('./fabricLakehouse', () => ({
+  createLakehouse: vi.fn(),
+  uploadEntityTable: vi.fn(),
+}));
+vi.mock('./fabricSemanticModel', () => ({
+  createSemanticModel: vi.fn(),
+}));
+vi.mock('./fabricGraphQL', () => ({
+  createGraphQLApi: vi.fn(),
+}));
+vi.mock('./sampleDataGenerator', () => ({
+  generateSampleData: vi.fn(),
+}));
+
+import { deployToFabric, type DeployConfig, type DeployStep } from './fabricDeployPipeline';
+import { acquireFabricToken } from './msalAuth';
+import { createOntology } from './fabric';
+import { createLakehouse, uploadEntityTable } from './fabricLakehouse';
+import { createSemanticModel } from './fabricSemanticModel';
+import { createGraphQLApi } from './fabricGraphQL';
+import { generateSampleData } from './sampleDataGenerator';
+
+const testOntology = {
+  name: 'TestOntology',
+  entityTypes: [
+    {
+      id: 'customer',
+      name: 'Customer',
+      icon: '👤',
+      color: '#fff',
+      properties: [{ name: 'id', type: 'string', isIdentifier: true }],
+    },
+  ],
+  relationships: [],
+};
+
+function fullConfig(overrides: Partial<DeployConfig> = {}): DeployConfig {
+  return {
+    workspaceId: 'ws-1',
+    ontologies: [testOntology as any],
+    createOntologyItem: true,
+    createLakehouse: true,
+    createSemanticModel: true,
+    createGraphQLApi: true,
+    accessToken: 'pre-token',
+    accountName: 'Test User',
+    ...overrides,
+  };
+}
+
+describe('fabricDeployPipeline', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (acquireFabricToken as any).mockResolvedValue({ accessToken: 'tok', account: { name: 'User' } });
+    (createOntology as any).mockResolvedValue({ id: 'ont-1', displayName: 'TestOntology' });
+    (createLakehouse as any).mockResolvedValue({ id: 'lh-1', displayName: 'TestOntology_Lakehouse' });
+    (uploadEntityTable as any).mockResolvedValue(undefined);
+    (createSemanticModel as any).mockResolvedValue({ id: 'sm-1', displayName: 'TestOntology_SemanticModel' });
+    (createGraphQLApi as any).mockResolvedValue({ id: 'gql-1', displayName: 'TestOntology - GraphQL API' });
+    (generateSampleData as any).mockReturnValue({
+      tables: new Map([['Customer', [{ id: '1', entityTypeId: 'customer', values: {} }]]]),
+    });
+  });
+
+  describe('Authentication', () => {
+    it('uses pre-acquired token when accessToken is provided (does NOT call acquireFabricToken)', async () => {
+      const config = fullConfig();
+      const onProgress = vi.fn();
+
+      await deployToFabric(config, onProgress);
+
+      expect(acquireFabricToken).not.toHaveBeenCalled();
+    });
+
+    it('calls acquireFabricToken when no accessToken provided', async () => {
+      const config = fullConfig({ accessToken: undefined });
+      const onProgress = vi.fn();
+
+      await deployToFabric(config, onProgress);
+
+      expect(acquireFabricToken).toHaveBeenCalled();
+    });
+
+    it('auth failure returns early with error step, no further steps run', async () => {
+      (acquireFabricToken as any).mockRejectedValue(new Error('Auth failed'));
+      const config = fullConfig({ accessToken: undefined });
+      const onProgress = vi.fn();
+
+      const result = await deployToFabric(config, onProgress);
+
+      expect(result.steps).toContainEqual(
+        expect.objectContaining({
+          id: 'authenticate',
+          status: 'error',
+        })
+      );
+      // Ensure only authenticate step is in result (auth failures return immediately)
+      expect(result.steps.filter(s => s.status !== 'pending').length).toBe(1);
+      expect(createOntology).not.toHaveBeenCalled();
+      expect(createLakehouse).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('Full pipeline (all flags true)', () => {
+    it('happy path — all steps succeed, result contains all IDs', async () => {
+      const config = fullConfig();
+      const onProgress = vi.fn();
+
+      const result = await deployToFabric(config, onProgress);
+
+      expect(result.steps).toContainEqual(
+        expect.objectContaining({ id: 'authenticate', status: 'success' })
+      );
+      expect(result.steps).toContainEqual(
+        expect.objectContaining({ id: 'ontology', status: 'success' })
+      );
+      expect(result.steps).toContainEqual(
+        expect.objectContaining({ id: 'lakehouse', status: 'success' })
+      );
+      expect(result.steps).toContainEqual(
+        expect.objectContaining({ id: 'populate-tables', status: 'success' })
+      );
+      expect(result.steps).toContainEqual(
+        expect.objectContaining({ id: 'semantic-model', status: 'success' })
+      );
+      expect(result.steps).toContainEqual(
+        expect.objectContaining({ id: 'graphql-api', status: 'success' })
+      );
+
+      // Check result contains IDs
+      expect(result.lakehouseId).toBe('lh-1');
+      expect(result.semanticModelResults[0]?.id).toBe('sm-1');
+      expect(result.graphQLApiResults[0]?.id).toBe('gql-1');
+    });
+
+    it('verify onProgress is called with correct step statuses (running → success)', async () => {
+      const config = fullConfig();
+      const onProgress = vi.fn();
+
+      await deployToFabric(config, onProgress);
+
+      // Should be called multiple times
+      expect(onProgress).toHaveBeenCalled();
+      const calls = onProgress.mock.calls;
+      expect(calls.length).toBeGreaterThan(1); // At least initial call + one update
+
+      // Verify structure: each call should contain an array of steps
+      for (const call of calls) {
+        expect(Array.isArray(call[0])).toBe(true);
+        const steps = call[0] as any[];
+        expect(steps.length).toBeGreaterThan(0);
+        for (const step of steps) {
+          expect(step).toHaveProperty('id');
+          expect(step).toHaveProperty('status');
+          expect(step).toHaveProperty('label');
+        }
+      }
+
+      // Verify some expected steps exist in the final result
+      const lastCall = calls[calls.length - 1][0] as any[];
+      const lastCallStepIds = new Set(lastCall.map((s: any) => s.id));
+      expect(lastCallStepIds.has('authenticate')).toBe(true);
+      expect(lastCallStepIds.has('ontology')).toBe(true);
+      expect(lastCallStepIds.has('lakehouse')).toBe(true);
+
+      // Verify that at least authenticate reached success status
+      const authStep = lastCall.find((s: any) => s.id === 'authenticate');
+      expect(authStep?.status).toBe('success');
+    });
+  });
+
+  describe('Conditional steps', () => {
+    it('createOntologyItem=false → ontology step skipped entirely', async () => {
+      const config = fullConfig({ createOntologyItem: false });
+      const onProgress = vi.fn();
+
+      const result = await deployToFabric(config, onProgress);
+
+      expect(result.steps).not.toContainEqual(
+        expect.objectContaining({ name: 'ontology' })
+      );
+      expect(createOntology).not.toHaveBeenCalled();
+    });
+
+    it('createLakehouse=false → lakehouse and populate-tables steps skipped', async () => {
+      const config = fullConfig({ createLakehouse: false });
+      const onProgress = vi.fn();
+
+      const result = await deployToFabric(config, onProgress);
+
+      expect(result.steps).not.toContainEqual(
+        expect.objectContaining({ name: 'lakehouse' })
+      );
+      expect(result.steps).not.toContainEqual(
+        expect.objectContaining({ name: 'populate-tables' })
+      );
+      expect(createLakehouse).not.toHaveBeenCalled();
+      expect(uploadEntityTable).not.toHaveBeenCalled();
+    });
+
+    it('createSemanticModel=false → semantic-model step skipped', async () => {
+      const config = fullConfig({ createSemanticModel: false });
+      const onProgress = vi.fn();
+
+      const result = await deployToFabric(config, onProgress);
+
+      expect(result.steps).not.toContainEqual(
+        expect.objectContaining({ name: 'semantic-model' })
+      );
+      expect(createSemanticModel).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('Error handling', () => {
+    it('lakehouse creation fails → populate-tables, semantic-model, graphql-api all skipped', async () => {
+      (createLakehouse as any).mockRejectedValue(new Error('Lakehouse failed'));
+      const config = fullConfig();
+      const onProgress = vi.fn();
+
+      const result = await deployToFabric(config, onProgress);
+
+      expect(result.steps).toContainEqual(
+        expect.objectContaining({ id: 'lakehouse', status: 'error' })
+      );
+      expect(result.steps).toContainEqual(
+        expect.objectContaining({ id: 'populate-tables', status: 'skipped' })
+      );
+      expect(result.steps).toContainEqual(
+        expect.objectContaining({ id: 'semantic-model', status: 'skipped' })
+      );
+      expect(result.steps).toContainEqual(
+        expect.objectContaining({ id: 'graphql-api', status: 'skipped' })
+      );
+      expect(uploadEntityTable).not.toHaveBeenCalled();
+    });
+
+    it('ontology creation fails → step has error, but pipeline continues to lakehouse', async () => {
+      (createOntology as any).mockRejectedValue(new Error('Ontology failed'));
+      const config = fullConfig();
+      const onProgress = vi.fn();
+
+      const result = await deployToFabric(config, onProgress);
+
+      expect(result.steps).toContainEqual(
+        expect.objectContaining({ id: 'ontology', status: 'error' })
+      );
+      // Lakehouse should still be attempted
+      expect(result.steps).toContainEqual(
+        expect.objectContaining({ id: 'lakehouse', status: 'success' })
+      );
+      expect(createLakehouse).toHaveBeenCalled();
+    });
+
+    it('semantic model creation fails → graphql-api still runs (independent)', async () => {
+      (createSemanticModel as any).mockRejectedValue(new Error('Semantic model failed'));
+      const config = fullConfig();
+      const onProgress = vi.fn();
+
+      const result = await deployToFabric(config, onProgress);
+
+      expect(result.steps).toContainEqual(
+        expect.objectContaining({ id: 'semantic-model', status: 'error' })
+      );
+      // GraphQL API should still be attempted
+      expect(result.steps).toContainEqual(
+        expect.objectContaining({ id: 'graphql-api', status: 'success' })
+      );
+      expect(createGraphQLApi).toHaveBeenCalled();
+    });
+  });
+
+  describe('Table population', () => {
+    it('generateSampleData produces tables → uploadEntityTable called for each table', async () => {
+      const config = fullConfig();
+      const onProgress = vi.fn();
+
+      await deployToFabric(config, onProgress);
+
+      // Should have been called at least once for the 'Customer' table
+      expect(uploadEntityTable).toHaveBeenCalled();
+      // Signature: uploadEntityTable(workspaceId, lakehouseId, token, tableId, instances)
+      expect(uploadEntityTable).toHaveBeenCalledWith(
+        'ws-1',         // workspaceId
+        'lh-1',         // lakehouseId
+        'pre-token',    // token
+        'Customer',     // tableId
+        expect.any(Array) // instances
+      );
+    });
+  });
+});

--- a/src/lib/fabricDeployPipeline.ts
+++ b/src/lib/fabricDeployPipeline.ts
@@ -1,0 +1,272 @@
+/**
+ * Fabric deployment pipeline — orchestrates full solution deployment.
+ *
+ * Sequence:
+ *   1. Authenticate via MSAL
+ *   2. Create Fabric IQ Ontology
+ *   3. Create Lakehouse + populate tables with sample data
+ *   4. Create Semantic Model bound to Lakehouse
+ *   5. Create GraphQL API backed by Lakehouse
+ */
+
+import type { Ontology } from '../data/ontology';
+import { acquireFabricToken } from './msalAuth';
+import { createOntology, type FabricOntologyResponse } from './fabric';
+import { createLakehouse, uploadEntityTable } from './fabricLakehouse';
+import { createSemanticModel, type SemanticModelResponse } from './fabricSemanticModel';
+import { createGraphQLApi, type GraphQLApiResponse } from './fabricGraphQL';
+import { generateSampleData } from './sampleDataGenerator';
+
+// ─── Types ─────────────────────────────────────────────────────────────────
+
+export type DeployStepId =
+  | 'authenticate'
+  | 'ontology'
+  | 'lakehouse'
+  | 'populate-tables'
+  | 'semantic-model'
+  | 'graphql-api';
+
+export type DeployStepStatus = 'pending' | 'running' | 'success' | 'error' | 'skipped';
+
+export interface DeployStep {
+  id: DeployStepId;
+  label: string;
+  status: DeployStepStatus;
+  error?: string;
+  resultId?: string;
+  resultName?: string;
+}
+
+export interface DeployConfig {
+  workspaceId: string;
+  ontologies: Ontology[];
+  createOntologyItem: boolean;
+  createLakehouse: boolean;
+  createSemanticModel: boolean;
+  createGraphQLApi: boolean;
+  /** Pre-acquired access token — skips the authenticate step if provided */
+  accessToken?: string;
+  accountName?: string;
+}
+
+export interface DeployResult {
+  steps: DeployStep[];
+  ontologyResults: FabricOntologyResponse[];
+  lakehouseId?: string;
+  lakehouseName?: string;
+  semanticModelResults: SemanticModelResponse[];
+  graphQLApiResults: GraphQLApiResponse[];
+}
+
+export type OnProgress = (steps: DeployStep[]) => void;
+
+// ─── Pipeline ──────────────────────────────────────────────────────────────
+
+function createSteps(config: DeployConfig): DeployStep[] {
+  const steps: DeployStep[] = [
+    { id: 'authenticate', label: 'Authenticate with Microsoft', status: 'pending' },
+  ];
+
+  if (config.createOntologyItem) {
+    steps.push({ id: 'ontology', label: `Create Ontology (${config.ontologies.length} items)`, status: 'pending' });
+  }
+  if (config.createLakehouse) {
+    steps.push({ id: 'lakehouse', label: 'Create Lakehouse', status: 'pending' });
+    steps.push({ id: 'populate-tables', label: 'Populate data tables', status: 'pending' });
+  }
+  if (config.createSemanticModel) {
+    steps.push({ id: 'semantic-model', label: 'Create Semantic Model', status: 'pending' });
+  }
+  if (config.createGraphQLApi) {
+    steps.push({ id: 'graphql-api', label: 'Create GraphQL API', status: 'pending' });
+  }
+
+  return steps;
+}
+
+function updateStep(
+  steps: DeployStep[],
+  id: DeployStepId,
+  update: Partial<DeployStep>,
+  onProgress: OnProgress,
+): void {
+  const step = steps.find(s => s.id === id);
+  if (step) Object.assign(step, update);
+  onProgress([...steps]);
+}
+
+/**
+ * Execute the full deployment pipeline.
+ */
+export async function deployToFabric(
+  config: DeployConfig,
+  onProgress: OnProgress,
+): Promise<DeployResult> {
+  const steps = createSteps(config);
+  onProgress(steps);
+
+  const result: DeployResult = {
+    steps,
+    ontologyResults: [],
+    semanticModelResults: [],
+    graphQLApiResults: [],
+  };
+
+  // Step 1: Authenticate (use pre-acquired token if available)
+  updateStep(steps, 'authenticate', { status: 'running' }, onProgress);
+  let token: string;
+  try {
+    if (config.accessToken) {
+      token = config.accessToken;
+      updateStep(steps, 'authenticate', {
+        status: 'success',
+        resultName: config.accountName ?? 'Pre-authenticated',
+      }, onProgress);
+    } else {
+      const authResult = await acquireFabricToken();
+      token = authResult.accessToken;
+      updateStep(steps, 'authenticate', {
+        status: 'success',
+        resultName: authResult.account.name,
+      }, onProgress);
+    }
+  } catch (err) {
+    updateStep(steps, 'authenticate', {
+      status: 'error',
+      error: err instanceof Error ? err.message : 'Authentication failed',
+    }, onProgress);
+    return result;
+  }
+
+  // Step 2: Create Ontology items
+  if (config.createOntologyItem) {
+    updateStep(steps, 'ontology', { status: 'running' }, onProgress);
+    try {
+      for (const ont of config.ontologies) {
+        const created = await createOntology(config.workspaceId, token, ont);
+        result.ontologyResults.push(created);
+      }
+      updateStep(steps, 'ontology', {
+        status: 'success',
+        resultId: result.ontologyResults[0]?.id,
+        resultName: `${result.ontologyResults.length} ontologies created`,
+      }, onProgress);
+    } catch (err) {
+      updateStep(steps, 'ontology', {
+        status: 'error',
+        error: err instanceof Error ? err.message : 'Failed to create ontology',
+      }, onProgress);
+    }
+  }
+
+  // Step 3: Create Lakehouse
+  let lakehouseId: string | undefined;
+  if (config.createLakehouse) {
+    updateStep(steps, 'lakehouse', { status: 'running' }, onProgress);
+    try {
+      const lhName = `${config.ontologies[0]?.name ?? 'Ontology'}_Lakehouse`.replace(/[^a-zA-Z0-9_]/g, '_');
+      const lh = await createLakehouse(
+        config.workspaceId, token, lhName,
+        `Auto-generated lakehouse for ${config.ontologies.map(o => o.name).join(', ')}`,
+      );
+      lakehouseId = lh.id;
+      result.lakehouseId = lh.id;
+      result.lakehouseName = lh.displayName;
+      updateStep(steps, 'lakehouse', {
+        status: 'success',
+        resultId: lh.id,
+        resultName: lh.displayName,
+      }, onProgress);
+    } catch (err) {
+      updateStep(steps, 'lakehouse', {
+        status: 'error',
+        error: err instanceof Error ? err.message : 'Failed to create lakehouse',
+      }, onProgress);
+    }
+
+    // Step 4: Populate tables
+    if (lakehouseId) {
+      updateStep(steps, 'populate-tables', { status: 'running' }, onProgress);
+      try {
+        let tableCount = 0;
+        for (const ont of config.ontologies) {
+          const data = generateSampleData(ont);
+          for (const [tableName, instances] of data.tables) {
+            await uploadEntityTable(config.workspaceId, lakehouseId, token, tableName, instances);
+            tableCount++;
+          }
+        }
+        updateStep(steps, 'populate-tables', {
+          status: 'success',
+          resultName: `${tableCount} tables populated`,
+        }, onProgress);
+      } catch (err) {
+        updateStep(steps, 'populate-tables', {
+          status: 'error',
+          error: err instanceof Error ? err.message : 'Failed to populate tables',
+        }, onProgress);
+      }
+    } else {
+      updateStep(steps, 'populate-tables', { status: 'skipped', error: 'Lakehouse not created' }, onProgress);
+    }
+  }
+
+  // Step 5: Create Semantic Model
+  if (config.createSemanticModel) {
+    updateStep(steps, 'semantic-model', { status: 'running' }, onProgress);
+    if (lakehouseId) {
+      try {
+        for (const ont of config.ontologies) {
+          const sm = await createSemanticModel(config.workspaceId, token, ont, lakehouseId);
+          result.semanticModelResults.push(sm);
+        }
+        updateStep(steps, 'semantic-model', {
+          status: 'success',
+          resultId: result.semanticModelResults[0]?.id,
+          resultName: `${result.semanticModelResults.length} models created`,
+        }, onProgress);
+      } catch (err) {
+        updateStep(steps, 'semantic-model', {
+          status: 'error',
+          error: err instanceof Error ? err.message : 'Failed to create semantic model',
+        }, onProgress);
+      }
+    } else {
+      updateStep(steps, 'semantic-model', { status: 'skipped', error: 'Lakehouse required' }, onProgress);
+    }
+  }
+
+  // Step 6: Create GraphQL API
+  if (config.createGraphQLApi) {
+    updateStep(steps, 'graphql-api', { status: 'running' }, onProgress);
+    if (lakehouseId) {
+      try {
+        for (const ont of config.ontologies) {
+          const api = await createGraphQLApi(
+            config.workspaceId, token,
+            `${ont.name} - GraphQL API`,
+            `GraphQL API for ${ont.name} ontology`,
+            lakehouseId,
+          );
+          result.graphQLApiResults.push(api);
+        }
+        updateStep(steps, 'graphql-api', {
+          status: 'success',
+          resultId: result.graphQLApiResults[0]?.id,
+          resultName: `${result.graphQLApiResults.length} APIs created`,
+        }, onProgress);
+      } catch (err) {
+        updateStep(steps, 'graphql-api', {
+          status: 'error',
+          error: err instanceof Error ? err.message : 'Failed to create GraphQL API',
+        }, onProgress);
+      }
+    } else {
+      updateStep(steps, 'graphql-api', { status: 'skipped', error: 'Lakehouse required' }, onProgress);
+    }
+  }
+
+  result.steps = steps;
+  return result;
+}

--- a/src/lib/fabricGraphQL.test.ts
+++ b/src/lib/fabricGraphQL.test.ts
@@ -1,0 +1,326 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { createGraphQLApi, GraphQLApiResponse } from './fabricGraphQL';
+
+describe('fabricGraphQL', () => {
+  const mockWorkspaceId = 'ws-123';
+  const mockToken = 'token-abc';
+  const mockDisplayName = 'Test GraphQL API';
+  const mockDescription = 'Test description';
+  const mockLakehouseId = 'lakehouse-xyz';
+
+  beforeEach(() => {
+    vi.stubGlobal('fetch', vi.fn());
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.clearAllMocks();
+  });
+
+  it('should return response body on direct 200 success', async () => {
+    const mockResponse: GraphQLApiResponse = {
+      id: 'gql-1',
+      displayName: mockDisplayName,
+      description: mockDescription,
+      type: 'GraphQLApi',
+      workspaceId: mockWorkspaceId,
+    };
+
+    (fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      status: 200,
+      ok: true,
+      json: vi.fn().mockResolvedValueOnce(mockResponse),
+    });
+
+    const result = await createGraphQLApi(
+      mockWorkspaceId,
+      mockToken,
+      mockDisplayName,
+      mockDescription,
+      mockLakehouseId,
+    );
+
+    expect(result).toEqual(mockResponse);
+    expect(fetch).toHaveBeenCalledOnce();
+  });
+
+  it('should throw on direct non-OK response', async () => {
+    const errorBody = 'Unauthorized access';
+
+    (fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      status: 401,
+      ok: false,
+      text: vi.fn().mockResolvedValueOnce(errorBody),
+    });
+
+    await expect(
+      createGraphQLApi(
+        mockWorkspaceId,
+        mockToken,
+        mockDisplayName,
+        mockDescription,
+        mockLakehouseId,
+      ),
+    ).rejects.toThrow(/Failed to create GraphQL API.*401.*Unauthorized/);
+  });
+
+  it('should poll operation and return match on 202 with operation-id', async () => {
+    const mockApiResponse: GraphQLApiResponse = {
+      id: 'gql-123',
+      displayName: mockDisplayName,
+      description: mockDescription,
+      type: 'GraphQLApi',
+      workspaceId: mockWorkspaceId,
+    };
+
+    const mockHeaders = new Map([['x-ms-operation-id', 'op-456']]);
+
+    // First call: POST to create (returns 202)
+    (fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      status: 202,
+      ok: false,
+      headers: mockHeaders,
+    });
+
+    // Second call: GET operation status (returns Succeeded)
+    (fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      status: 200,
+      ok: true,
+      json: vi.fn().mockResolvedValueOnce({ status: 'Succeeded' }),
+    });
+
+    // Third call: GET list of APIs (returns match)
+    (fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      status: 200,
+      ok: true,
+      json: vi.fn().mockResolvedValueOnce({
+        value: [mockApiResponse],
+      }),
+    });
+
+    const result = await createGraphQLApi(
+      mockWorkspaceId,
+      mockToken,
+      mockDisplayName,
+      mockDescription,
+      mockLakehouseId,
+    );
+
+    expect(result).toEqual(mockApiResponse);
+    expect(fetch).toHaveBeenCalledTimes(3);
+  });
+
+  it('should skip polling and list APIs on 202 without operation-id', async () => {
+    const mockApiResponse: GraphQLApiResponse = {
+      id: 'gql-789',
+      displayName: mockDisplayName,
+      description: mockDescription,
+      type: 'GraphQLApi',
+      workspaceId: mockWorkspaceId,
+    };
+
+    const mockHeaders = new Map([]);
+
+    // First call: POST to create (returns 202, no operation-id)
+    (fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      status: 202,
+      ok: false,
+      headers: mockHeaders,
+    });
+
+    // Second call: GET list of APIs (returns match)
+    (fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      status: 200,
+      ok: true,
+      json: vi.fn().mockResolvedValueOnce({
+        value: [mockApiResponse],
+      }),
+    });
+
+    const result = await createGraphQLApi(
+      mockWorkspaceId,
+      mockToken,
+      mockDisplayName,
+      mockDescription,
+      mockLakehouseId,
+    );
+
+    expect(result).toEqual(mockApiResponse);
+    // Should skip polling, only call create and list
+    expect(fetch).toHaveBeenCalledTimes(2);
+  });
+
+  it('should throw when poll returns Failed status', async () => {
+    const mockHeaders = new Map([['x-ms-operation-id', 'op-fail']]);
+
+    // First call: POST to create (returns 202)
+    (fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      status: 202,
+      ok: false,
+      headers: mockHeaders,
+    });
+
+    // Second call: GET operation status (returns Failed)
+    (fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      status: 200,
+      ok: true,
+      json: vi.fn().mockResolvedValueOnce({
+        status: 'Failed',
+        error: { message: 'Lakehouse not found' },
+      }),
+    });
+
+    await expect(
+      createGraphQLApi(
+        mockWorkspaceId,
+        mockToken,
+        mockDisplayName,
+        mockDescription,
+        mockLakehouseId,
+      ),
+    ).rejects.toThrow(/Operation failed.*Lakehouse not found/);
+
+    expect(fetch).toHaveBeenCalledTimes(2);
+  });
+
+  it('should include correct request body structure with base64 payloads', async () => {
+    const mockResponse: GraphQLApiResponse = {
+      id: 'gql-struct',
+      displayName: mockDisplayName,
+      description: mockDescription,
+      type: 'GraphQLApi',
+      workspaceId: mockWorkspaceId,
+    };
+
+    (fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      status: 200,
+      ok: true,
+      json: vi.fn().mockResolvedValueOnce(mockResponse),
+    });
+
+    await createGraphQLApi(
+      mockWorkspaceId,
+      mockToken,
+      mockDisplayName,
+      mockDescription,
+      mockLakehouseId,
+    );
+
+    const fetchCall = (fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(fetchCall[0]).toContain(`/workspaces/${mockWorkspaceId}/graphQLApis`);
+    expect(fetchCall[1].method).toBe('POST');
+    expect(fetchCall[1].headers['Content-Type']).toBe('application/json');
+    expect(fetchCall[1].headers['Authorization']).toBe(`Bearer ${mockToken}`);
+
+    const body = JSON.parse(fetchCall[1].body);
+    expect(body.displayName).toBe(mockDisplayName);
+    expect(body.description).toBe(mockDescription);
+
+    // Verify definition parts structure
+    expect(body.definition.parts).toHaveLength(2);
+
+    const platformPart = body.definition.parts[0];
+    expect(platformPart.path).toBe('.platform');
+    expect(platformPart.payloadType).toBe('InlineBase64');
+    const platformPayload = JSON.parse(atob(platformPart.payload));
+    expect(platformPayload.metadata.type).toBe('GraphQLApi');
+    expect(platformPayload.metadata.displayName).toBe(mockDisplayName);
+
+    const definitionPart = body.definition.parts[1];
+    expect(definitionPart.path).toBe('definition.json');
+    expect(definitionPart.payloadType).toBe('InlineBase64');
+    const definitionPayload = JSON.parse(atob(definitionPart.payload));
+    expect(definitionPayload.dataSourceId).toBe(mockLakehouseId);
+    expect(definitionPayload.dataSourceType).toBe('Lakehouse');
+  });
+
+  it('should throw when created API not found in list', async () => {
+    const mockHeaders = new Map([['x-ms-operation-id', 'op-notfound']]);
+
+    // First call: POST to create (returns 202)
+    (fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      status: 202,
+      ok: false,
+      headers: mockHeaders,
+    });
+
+    // Second call: GET operation status (returns Succeeded)
+    (fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      status: 200,
+      ok: true,
+      json: vi.fn().mockResolvedValueOnce({ status: 'Succeeded' }),
+    });
+
+    // Third call: GET list of APIs (returns empty list)
+    (fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      status: 200,
+      ok: true,
+      json: vi.fn().mockResolvedValueOnce({
+        value: [],
+      }),
+    });
+
+    await expect(
+      createGraphQLApi(
+        mockWorkspaceId,
+        mockToken,
+        mockDisplayName,
+        mockDescription,
+        mockLakehouseId,
+      ),
+    ).rejects.toThrow('GraphQL API created but not found');
+  });
+
+  it('should pass correct authorization headers for all fetch calls', async () => {
+    const mockApiResponse: GraphQLApiResponse = {
+      id: 'gql-auth',
+      displayName: mockDisplayName,
+      description: mockDescription,
+      type: 'GraphQLApi',
+      workspaceId: mockWorkspaceId,
+    };
+
+    const mockHeaders = new Map([['x-ms-operation-id', 'op-auth']]);
+
+    // First call: POST to create
+    (fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      status: 202,
+      ok: false,
+      headers: mockHeaders,
+    });
+
+    // Second call: GET operation status
+    (fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      status: 200,
+      ok: true,
+      json: vi.fn().mockResolvedValueOnce({ status: 'Succeeded' }),
+    });
+
+    // Third call: GET list of APIs
+    (fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      status: 200,
+      ok: true,
+      json: vi.fn().mockResolvedValueOnce({
+        value: [mockApiResponse],
+      }),
+    });
+
+    await createGraphQLApi(
+      mockWorkspaceId,
+      mockToken,
+      mockDisplayName,
+      mockDescription,
+      mockLakehouseId,
+    );
+
+    const calls = (fetch as ReturnType<typeof vi.fn>).mock.calls;
+
+    // Verify all calls have correct authorization
+    calls.forEach((call) => {
+      expect(call[1].headers['Authorization']).toBe(`Bearer ${mockToken}`);
+    });
+
+    // Verify operation endpoint
+    expect(calls[1][0]).toContain('/operations/op-auth');
+  });
+});

--- a/src/lib/fabricGraphQL.ts
+++ b/src/lib/fabricGraphQL.ts
@@ -1,0 +1,107 @@
+/**
+ * Fabric GraphQL API client — creates GraphQL API items backed by a Lakehouse.
+ *
+ * API Reference:
+ *   https://learn.microsoft.com/en-us/rest/api/fabric/graphqlapi/items/create-graphql-api
+ */
+
+const FABRIC_API_BASE = 'https://api.fabric.microsoft.com/v1';
+
+export interface GraphQLApiResponse {
+  id: string;
+  displayName: string;
+  description: string;
+  type: 'GraphQLApi';
+  workspaceId: string;
+}
+
+async function pollOperation(operationId: string, token: string): Promise<void> {
+  for (let i = 0; i < 60; i++) {
+    await new Promise(resolve => setTimeout(resolve, 3000));
+    const res = await fetch(`${FABRIC_API_BASE}/operations/${operationId}`, {
+      headers: { 'Authorization': `Bearer ${token}` },
+    });
+    if (res.ok) {
+      const body = await res.json();
+      if (body.status === 'Succeeded') return;
+      if (body.status === 'Failed') {
+        throw new Error(`Operation failed: ${body.error?.message ?? 'Unknown'}`);
+      }
+    }
+  }
+  throw new Error('GraphQL API creation timed out');
+}
+
+/**
+ * Create a GraphQL API item in a Fabric workspace backed by a Lakehouse.
+ */
+export async function createGraphQLApi(
+  workspaceId: string,
+  token: string,
+  displayName: string,
+  description: string,
+  lakehouseId: string,
+): Promise<GraphQLApiResponse> {
+  const res = await fetch(
+    `${FABRIC_API_BASE}/workspaces/${workspaceId}/graphQLApis`,
+    {
+      method: 'POST',
+      headers: {
+        'Authorization': `Bearer ${token}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        displayName,
+        description,
+        definition: {
+          parts: [
+            {
+              path: '.platform',
+              payload: btoa(JSON.stringify({
+                metadata: {
+                  type: 'GraphQLApi',
+                  displayName,
+                },
+              })),
+              payloadType: 'InlineBase64',
+            },
+            {
+              path: 'definition.json',
+              payload: btoa(JSON.stringify({
+                dataSourceId: lakehouseId,
+                dataSourceType: 'Lakehouse',
+              })),
+              payloadType: 'InlineBase64',
+            },
+          ],
+        },
+      }),
+    },
+  );
+
+  if (res.status === 202) {
+    const opId = res.headers.get('x-ms-operation-id');
+    if (opId) await pollOperation(opId, token);
+
+    // Fetch created API
+    const listRes = await fetch(
+      `${FABRIC_API_BASE}/workspaces/${workspaceId}/graphQLApis`,
+      { headers: { 'Authorization': `Bearer ${token}` } },
+    );
+    if (listRes.ok) {
+      const list = await listRes.json();
+      const found = list.value?.find(
+        (a: GraphQLApiResponse) => a.displayName === displayName,
+      );
+      if (found) return found;
+    }
+    throw new Error('GraphQL API created but not found');
+  }
+
+  if (!res.ok) {
+    const body = await res.text();
+    throw new Error(`Failed to create GraphQL API: ${res.status} ${body}`);
+  }
+
+  return await res.json() as GraphQLApiResponse;
+}

--- a/src/lib/fabricLakehouse.test.ts
+++ b/src/lib/fabricLakehouse.test.ts
@@ -1,0 +1,195 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { createLakehouse, uploadEntityTable, copyDeltaTable, deleteLakehouse } from './fabricLakehouse';
+import { instancesToCSV } from './sampleDataGenerator';
+
+// Mock the sampleDataGenerator module
+vi.mock('./sampleDataGenerator', () => ({
+  instancesToCSV: vi.fn(),
+}));
+
+// Helper function to mock Response objects
+function mockRes(body: unknown, status = 200, headers: Record<string, string> = {}) {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: () => Promise.resolve(body),
+    text: () => Promise.resolve(typeof body === 'string' ? body : JSON.stringify(body)),
+    headers: { get: (k: string) => headers[k.toLowerCase()] ?? null },
+    arrayBuffer: () => Promise.resolve(new ArrayBuffer(0)),
+  };
+}
+
+describe('fabricLakehouse', () => {
+  beforeEach(() => {
+    vi.stubGlobal('fetch', vi.fn());
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  describe('createLakehouse', () => {
+    it('should return lakehouse on direct 200 success', async () => {
+      const expectedLakehouse = { id: 'lh-123', displayName: 'TestLakehouse' };
+      (global.fetch as any).mockResolvedValueOnce(mockRes(expectedLakehouse, 200));
+
+      const result = await createLakehouse('token', 'workspace-id', 'TestLakehouse');
+
+      expect(result).toEqual(expectedLakehouse);
+      expect(global.fetch).toHaveBeenCalled();
+    });
+
+    it('should list and find by displayName on 202 with null result', async () => {
+      const expectedLakehouse = { id: 'lh-123', displayName: 'TestLakehouse' };
+      (global.fetch as any)
+        .mockResolvedValueOnce(mockRes(null, 202)) // Initial creation returns 202
+        .mockResolvedValueOnce(mockRes({ value: [expectedLakehouse] }, 200)); // List returns the lakehouse
+
+      const result = await createLakehouse('token', 'workspace-id', 'TestLakehouse');
+
+      expect(result).toEqual(expectedLakehouse);
+      expect(global.fetch).toHaveBeenCalledTimes(2);
+    });
+
+    it('should throw when 202 response lakehouse not found in list', async () => {
+      (global.fetch as any)
+        .mockResolvedValueOnce(mockRes(null, 202)) // Initial creation returns 202
+        .mockResolvedValueOnce(mockRes({ value: [] }, 200)); // List returns empty
+
+      await expect(
+        createLakehouse('token', 'workspace-id', 'TestLakehouse')
+      ).rejects.toThrow(/created but not found/i);
+    });
+
+    it('should throw error on non-OK response', async () => {
+      (global.fetch as any).mockResolvedValueOnce(mockRes({ error: 'Not found' }, 404));
+
+      await expect(
+        createLakehouse('token', 'workspace-id', 'TestLakehouse')
+      ).rejects.toThrow();
+    });
+  });
+
+  describe('uploadEntityTable', () => {
+    it('should skip when instancesToCSV returns empty', async () => {
+      (instancesToCSV as any).mockReturnValueOnce('');
+
+      await uploadEntityTable('token', 'lh-id', 'MyTable', []);
+
+      expect(global.fetch).not.toHaveBeenCalled();
+    });
+
+    it('should skip when instancesToCSV returns null', async () => {
+      (instancesToCSV as any).mockReturnValueOnce(null);
+
+      await uploadEntityTable('token', 'lh-id', 'MyTable', []);
+
+      expect(global.fetch).not.toHaveBeenCalled();
+    });
+
+    it('should call PUT (create file), PATCH (append), PATCH (flush), POST (load table)', async () => {
+      const csvData = 'col1,col2\nval1,val2';
+      (instancesToCSV as any).mockReturnValueOnce(csvData);
+
+      (global.fetch as any)
+        .mockResolvedValueOnce(mockRes({ id: 'file-123' }, 201)) // PUT create file
+        .mockResolvedValueOnce(mockRes({}, 200)) // PATCH append
+        .mockResolvedValueOnce(mockRes({}, 200)) // PATCH flush
+        .mockResolvedValueOnce(mockRes({}, 200)); // POST load table
+
+      await uploadEntityTable('token', 'lh-id', 'MyTable', [{ id: '1' }]);
+
+      expect(global.fetch).toHaveBeenCalledTimes(4);
+      // Verify the methods and operations
+      const calls = (global.fetch as any).mock.calls;
+      expect(calls[0][1]?.method).toBe('PUT'); // create file
+      expect(calls[1][1]?.method).toBe('PATCH'); // append
+      expect(calls[2][1]?.method).toBe('PATCH'); // flush
+      expect(calls[3][1]?.method).toBe('POST'); // load table
+    });
+  });
+
+  describe('copyDeltaTable', () => {
+    it('should list files, create directories, copy data files before delta log files', async () => {
+      const listingResponse = {
+        paths: [
+          { name: 'lh-id/Tables/MyTable/_delta_log', isDirectory: 'true' },
+          { name: 'lh-id/Tables/MyTable/part-0.parquet', contentLength: '1024' },
+          { name: 'lh-id/Tables/MyTable/_delta_log/00000.json', contentLength: '256' },
+        ],
+      };
+
+      (global.fetch as any)
+        // List files
+        .mockResolvedValueOnce(mockRes(listingResponse, 200))
+        // Create target directory
+        .mockResolvedValueOnce(mockRes({}, 201))
+        // Create delta_log subdirectory
+        .mockResolvedValueOnce(mockRes({}, 201))
+        // Download parquet file
+        .mockResolvedValueOnce(mockRes({}, 200))
+        // PUT (create) parquet file
+        .mockResolvedValueOnce(mockRes({}, 201))
+        // PATCH (append) parquet file
+        .mockResolvedValueOnce(mockRes({}, 202))
+        // Download delta log file
+        .mockResolvedValueOnce(mockRes({}, 200))
+        // PUT (create) delta log file
+        .mockResolvedValueOnce(mockRes({}, 201))
+        // PATCH (append) delta log file
+        .mockResolvedValueOnce(mockRes({}, 202));
+
+      await copyDeltaTable('token', 'source-lh', 'dest-lh', 'MyTable');
+
+      expect(global.fetch).toHaveBeenCalled();
+      // Verify data files copied before delta log files
+      const calls = (global.fetch as any).mock.calls;
+      const parquetCall = calls.findIndex((call: any[]) =>
+        call[0]?.includes('part-0.parquet')
+      );
+      const deltaLogCall = calls.findIndex((call: any[]) =>
+        call[0]?.includes('00000.json')
+      );
+
+      if (parquetCall !== -1 && deltaLogCall !== -1) {
+        expect(parquetCall).toBeLessThan(deltaLogCall);
+      }
+    });
+  });
+
+  describe('deleteLakehouse', () => {
+    it('should return true on 200 OK', async () => {
+      (global.fetch as any).mockResolvedValueOnce(mockRes({}, 200));
+
+      const result = await deleteLakehouse('workspace-id', 'lh-123', 'token');
+
+      expect(result).toBe(true);
+    });
+
+    it('should return true on 204 No Content', async () => {
+      (global.fetch as any).mockResolvedValueOnce(mockRes({}, 204));
+
+      const result = await deleteLakehouse('workspace-id', 'lh-123', 'token');
+
+      expect(result).toBe(true);
+    });
+
+    it('should return false when fetch throws', async () => {
+      (global.fetch as any).mockRejectedValueOnce(new Error('Network error'));
+
+      const result = await deleteLakehouse('workspace-id', 'lh-123', 'token');
+
+      expect(result).toBe(false);
+    });
+
+    it('should return false on non-OK response like 404', async () => {
+      (global.fetch as any).mockResolvedValueOnce(mockRes({ error: 'Not found' }, 404));
+
+      const result = await deleteLakehouse('workspace-id', 'lh-123', 'token');
+
+      expect(result).toBe(false);
+    });
+  });
+});

--- a/src/lib/fabricLakehouse.ts
+++ b/src/lib/fabricLakehouse.ts
@@ -1,0 +1,362 @@
+/**
+ * Fabric Lakehouse API client — creates Lakehouses and uploads table data.
+ *
+ * API Reference:
+ *   https://learn.microsoft.com/en-us/rest/api/fabric/lakehouse/items/create-lakehouse
+ *   https://learn.microsoft.com/en-us/rest/api/fabric/lakehouse/tables/load-table
+ */
+
+import type { EntityInstance } from '../data/ontology';
+import { instancesToCSV } from './sampleDataGenerator';
+
+const FABRIC_API_BASE = 'https://api.fabric.microsoft.com/v1';
+const ONELAKE_BASE = 'https://onelake.dfs.fabric.microsoft.com';
+
+export interface LakehouseResponse {
+  id: string;
+  displayName: string;
+  description: string;
+  type: 'Lakehouse';
+  workspaceId: string;
+}
+
+async function fabricFetch<T>(
+  url: string,
+  token: string,
+  options: RequestInit = {},
+): Promise<T | null> {
+  const res = await fetch(url, {
+    ...options,
+    headers: {
+      'Authorization': `Bearer ${token}`,
+      'Content-Type': 'application/json',
+      ...options.headers,
+    },
+  });
+
+  if (res.status === 202) {
+    const operationId = res.headers.get('x-ms-operation-id');
+    if (operationId) {
+      await pollOperation(operationId, token);
+    }
+    return null;
+  }
+
+  if (res.status === 204) return null;
+
+  if (!res.ok) {
+    const body = await res.text();
+    throw new Error(`Fabric API error ${res.status}: ${body}`);
+  }
+
+  // Handle 200 with empty body (e.g., Load Table API)
+  const text = await res.text();
+  if (!text) return null;
+  return JSON.parse(text) as T;
+}
+
+async function pollOperation(operationId: string, token: string, maxAttempts = 60): Promise<void> {
+  for (let i = 0; i < maxAttempts; i++) {
+    await new Promise(resolve => setTimeout(resolve, 3000));
+    const res = await fetch(`${FABRIC_API_BASE}/operations/${operationId}`, {
+      headers: { 'Authorization': `Bearer ${token}` },
+    });
+    if (res.ok) {
+      const body = await res.json();
+      if (body.status === 'Succeeded') return;
+      if (body.status === 'Failed') {
+        throw new Error(`Operation failed: ${body.error?.message ?? 'Unknown error'}`);
+      }
+    }
+  }
+  throw new Error('Operation timed out');
+}
+
+/**
+ * Create a new Lakehouse in a Fabric workspace.
+ */
+export async function createLakehouse(
+  workspaceId: string,
+  token: string,
+  displayName: string,
+  description = '',
+): Promise<LakehouseResponse> {
+  // Omitting creationPayload creates a plain Lakehouse (no schemas).
+  // Including creationPayload with enableSchemas:true creates a schema-enabled one.
+  const result = await fabricFetch<LakehouseResponse>(
+    `${FABRIC_API_BASE}/workspaces/${workspaceId}/lakehouses`,
+    token,
+    {
+      method: 'POST',
+      body: JSON.stringify({ displayName, description }),
+    },
+  );
+
+  if (!result) {
+    // Created via long-running op — fetch it
+    const list = await fabricFetch<{ value: LakehouseResponse[] }>(
+      `${FABRIC_API_BASE}/workspaces/${workspaceId}/lakehouses`,
+      token,
+    );
+    const found = list?.value.find(l => l.displayName === displayName);
+    if (found) return found;
+    throw new Error('Lakehouse created but not found');
+  }
+
+  return result;
+}
+
+/**
+ * Upload a CSV file to OneLake Files area for a Lakehouse.
+ */
+async function uploadFileToOneLake(
+  workspaceId: string,
+  lakehouseId: string,
+  token: string,
+  filePath: string,
+  content: string,
+): Promise<void> {
+  const url = `${ONELAKE_BASE}/${workspaceId}/${lakehouseId}/Files/${filePath}?resource=file`;
+
+  // Create the file
+  const createRes = await fetch(url, {
+    method: 'PUT',
+    headers: {
+      'Authorization': `Bearer ${token}`,
+      'Content-Length': '0',
+    },
+  });
+
+  if (!createRes.ok && createRes.status !== 201) {
+    throw new Error(`Failed to create OneLake file: ${createRes.status}`);
+  }
+
+  // Append content
+  const blob = new Blob([content], { type: 'text/csv' });
+  const appendUrl = `${ONELAKE_BASE}/${workspaceId}/${lakehouseId}/Files/${filePath}?action=append&position=0`;
+  const appendRes = await fetch(appendUrl, {
+    method: 'PATCH',
+    headers: {
+      'Authorization': `Bearer ${token}`,
+      'Content-Type': 'application/octet-stream',
+    },
+    body: blob,
+  });
+
+  if (!appendRes.ok && appendRes.status !== 202) {
+    throw new Error(`Failed to append data: ${appendRes.status}`);
+  }
+
+  // Flush
+  const flushUrl = `${ONELAKE_BASE}/${workspaceId}/${lakehouseId}/Files/${filePath}?action=flush&position=${blob.size}`;
+  const flushRes = await fetch(flushUrl, {
+    method: 'PATCH',
+    headers: { 'Authorization': `Bearer ${token}` },
+  });
+
+  if (!flushRes.ok && flushRes.status !== 200) {
+    throw new Error(`Failed to flush file: ${flushRes.status}`);
+  }
+}
+
+/**
+ * Load a CSV file from Files into a managed Delta table.
+ */
+async function loadTable(
+  workspaceId: string,
+  lakehouseId: string,
+  token: string,
+  tableName: string,
+  csvPath: string,
+): Promise<void> {
+  await fabricFetch<void>(
+    `${FABRIC_API_BASE}/workspaces/${workspaceId}/lakehouses/${lakehouseId}/tables/${tableName}/load`,
+    token,
+    {
+      method: 'POST',
+      body: JSON.stringify({
+        relativePath: csvPath,
+        pathType: 'File',
+        mode: 'Overwrite',
+        formatOptions: {
+          format: 'Csv',
+          header: true,
+          delimiter: ',',
+        },
+      }),
+    },
+  );
+}
+
+/**
+ * Upload entity instances as a Delta table in the Lakehouse.
+ * Uses oneLakeToken for DFS file upload, fabricToken for Load Table API.
+ * When called with a single token, uses it for both (legacy behavior).
+ */
+export async function uploadEntityTable(
+  workspaceId: string,
+  lakehouseId: string,
+  token: string,
+  tableName: string,
+  instances: EntityInstance[],
+  fabricToken?: string,
+): Promise<void> {
+  const csv = instancesToCSV(instances);
+  if (!csv) return;
+
+  const csvPath = `staging/${tableName}.csv`;
+
+  // Upload CSV to Files area (OneLake DFS token)
+  await uploadFileToOneLake(workspaceId, lakehouseId, token, csvPath, csv);
+
+  // Load into managed Delta table (Fabric API token)
+  // relativePath must include Files/ prefix — it's relative to the Lakehouse root
+  await loadTable(workspaceId, lakehouseId, fabricToken ?? token, tableName, `Files/${csvPath}`);
+}
+
+/**
+ * Upload a binary file to OneLake via DFS (create → append → flush).
+ * Works for Parquet, Delta log JSON, and any other file type.
+ */
+async function uploadBinaryToOneLake(
+  workspaceId: string,
+  lakehouseId: string,
+  token: string,
+  fullPath: string,
+  content: ArrayBuffer,
+): Promise<void> {
+  const base = `${ONELAKE_BASE}/${workspaceId}/${lakehouseId}`;
+
+  // Create the file
+  const createRes = await fetch(`${base}/${fullPath}?resource=file`, {
+    method: 'PUT',
+    headers: { 'Authorization': `Bearer ${token}`, 'Content-Length': '0' },
+  });
+  if (!createRes.ok && createRes.status !== 201) {
+    throw new Error(`Failed to create file ${fullPath}: ${createRes.status}`);
+  }
+
+  if (content.byteLength === 0) return;
+
+  // Append content
+  const appendRes = await fetch(`${base}/${fullPath}?action=append&position=0`, {
+    method: 'PATCH',
+    headers: { 'Authorization': `Bearer ${token}`, 'Content-Type': 'application/octet-stream' },
+    body: content,
+  });
+  if (!appendRes.ok && appendRes.status !== 202) {
+    throw new Error(`Failed to append data to ${fullPath}: ${appendRes.status}`);
+  }
+
+  // Flush
+  const flushRes = await fetch(`${base}/${fullPath}?action=flush&position=${content.byteLength}`, {
+    method: 'PATCH',
+    headers: { 'Authorization': `Bearer ${token}` },
+  });
+  if (!flushRes.ok && flushRes.status !== 200) {
+    throw new Error(`Failed to flush ${fullPath}: ${flushRes.status}`);
+  }
+}
+
+/**
+ * Copy a Delta table from a plain (no-schema) Lakehouse into a
+ * schema-enabled Lakehouse's Tables/dbo/ path.
+ *
+ * The auto-provisioned Ontology Lakehouse has schemas enabled and the
+ * Load Table API doesn't work on it. This function copies the already-
+ * loaded Parquet + _delta_log files via OneLake DFS, which Fabric then
+ * auto-registers in its table catalog.
+ *
+ * Copy order: data files first, then _delta_log, to minimise the window
+ * where the catalog sees partial state.
+ */
+export async function copyDeltaTable(
+  workspaceId: string,
+  srcLakehouseId: string,
+  dstLakehouseId: string,
+  tableName: string,
+  oneLakeToken: string,
+): Promise<void> {
+  const srcBase = `${ONELAKE_BASE}/${workspaceId}/${srcLakehouseId}`;
+  const srcTableRoot = `Tables/${tableName}`;
+  const dstTableRoot = `Tables/dbo/${tableName}`;
+
+  // List all files recursively under the source table
+  const listRes = await fetch(
+    `${srcBase}/${srcTableRoot}?resource=filesystem&recursive=true`,
+    { headers: { 'Authorization': `Bearer ${oneLakeToken}` } },
+  );
+  if (!listRes.ok) {
+    throw new Error(`Failed to list table files for ${tableName}: ${listRes.status}`);
+  }
+  const listing: { paths: Array<{ name: string; isDirectory?: string; contentLength?: string }> } =
+    await listRes.json();
+
+  // Separate directories and files; sort so data files come before _delta_log
+  const dirs: string[] = [];
+  const dataFiles: string[] = [];
+  const logFiles: string[] = [];
+
+  for (const entry of listing.paths) {
+    // entry.name is fully qualified: "{lhId}/Tables/{table}/..."
+    const relativePath = entry.name.replace(/^.*?Tables\/[^/]+\//, '');
+    if (entry.isDirectory === 'true') {
+      dirs.push(relativePath);
+    } else if (relativePath.startsWith('_delta_log')) {
+      logFiles.push(relativePath);
+    } else {
+      dataFiles.push(relativePath);
+    }
+  }
+
+  // Create directories first
+  for (const dir of dirs) {
+    const dstPath = `${dstTableRoot}/${dir}`;
+    const res = await fetch(
+      `${ONELAKE_BASE}/${workspaceId}/${dstLakehouseId}/${dstPath}?resource=directory`,
+      { method: 'PUT', headers: { 'Authorization': `Bearer ${oneLakeToken}`, 'Content-Length': '0' } },
+    );
+    if (!res.ok && res.status !== 409) {
+      console.warn(`Failed to create directory ${dstPath}: ${res.status}`);
+    }
+  }
+
+  // Copy data files first, then delta log (minimises partial-table visibility)
+  const allFiles = [...dataFiles, ...logFiles];
+  for (const file of allFiles) {
+    const srcPath = `${srcTableRoot}/${file}`;
+    const dstPath = `${dstTableRoot}/${file}`;
+
+    // Download from source
+    const downloadRes = await fetch(`${srcBase}/${srcPath}`, {
+      headers: { 'Authorization': `Bearer ${oneLakeToken}` },
+    });
+    if (!downloadRes.ok) {
+      throw new Error(`Failed to download ${srcPath}: ${downloadRes.status}`);
+    }
+    const content = await downloadRes.arrayBuffer();
+
+    // Upload to destination
+    await uploadBinaryToOneLake(workspaceId, dstLakehouseId, oneLakeToken, dstPath, content);
+  }
+}
+
+/**
+ * Delete a Lakehouse from a Fabric workspace. Best-effort — does not
+ * throw on failure so callers can treat cleanup as optional.
+ */
+export async function deleteLakehouse(
+  workspaceId: string,
+  lakehouseId: string,
+  fabricToken: string,
+): Promise<boolean> {
+  try {
+    const res = await fetch(
+      `${FABRIC_API_BASE}/workspaces/${workspaceId}/lakehouses/${lakehouseId}`,
+      { method: 'DELETE', headers: { 'Authorization': `Bearer ${fabricToken}` } },
+    );
+    return res.ok || res.status === 204;
+  } catch {
+    return false;
+  }
+}

--- a/src/lib/fabricSemanticModel.test.ts
+++ b/src/lib/fabricSemanticModel.test.ts
@@ -1,0 +1,359 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { createSemanticModel } from './fabricSemanticModel';
+import type { Ontology } from '../data/ontology';
+
+// ─── Test Ontology Fixture ──────────────────────────────────────────────────
+
+const testOntology: Ontology = {
+  name: 'TestOntology',
+  description: 'Test ontology for semantic model creation',
+  entityTypes: [
+    {
+      id: 'customer',
+      name: 'Customer',
+      description: 'Customer entity',
+      icon: '👤',
+      color: '#fff',
+      properties: [
+        { name: 'customerId', type: 'string', isIdentifier: true },
+        { name: 'name', type: 'string' },
+        { name: 'age', type: 'integer' },
+        { name: 'balance', type: 'decimal' },
+        { name: 'active', type: 'boolean' },
+        { name: 'created', type: 'datetime' },
+      ],
+    },
+    {
+      id: 'order',
+      name: 'Order',
+      description: 'Order entity',
+      icon: '📦',
+      color: '#fff',
+      properties: [
+        { name: 'orderId', type: 'string', isIdentifier: true },
+        { name: 'total', type: 'double' },
+      ],
+    },
+  ],
+  relationships: [
+    { id: 'r1', name: 'places', from: 'customer', to: 'order', cardinality: '1:n' },
+  ],
+};
+
+// ─── Helper Functions ───────────────────────────────────────────────────────
+
+/**
+ * Decode base64 TMSL model from semantic model definition payload
+ */
+function decodeBase64ToJson(base64: string): unknown {
+  const binary = atob(base64);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) {
+    bytes[i] = binary.charCodeAt(i);
+  }
+  const text = new TextDecoder().decode(bytes);
+  return JSON.parse(text);
+}
+
+/**
+ * Extract model.bim payload from semantic model definition
+ */
+function extractModelPayload(definitionParts: Array<{ path: string; payload: string }>): unknown {
+  const modelPart = definitionParts.find(p => p.path === 'definition/model.bim');
+  if (!modelPart) throw new Error('No model.bim part found in definition');
+  return decodeBase64ToJson(modelPart.payload);
+}
+
+// ─── Tests ──────────────────────────────────────────────────────────────────
+
+describe('createSemanticModel', () => {
+  const workspaceId = 'ws-123';
+  const token = 'test-token';
+  const lakehouseId = 'lh-456';
+
+  beforeEach(() => {
+    vi.stubGlobal('fetch', vi.fn());
+    vi.stubGlobal('setTimeout', vi.fn((cb: () => void) => cb()));
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  // ─── Test 1: Direct 200/201 success ─────────────────────────────────────
+
+  it('returns response body on direct 200/201 success', async () => {
+    const mockResponse = {
+      id: 'model-123',
+      displayName: 'TestOntology - Semantic Model',
+      description: 'Auto-generated semantic model for TestOntology ontology',
+      type: 'SemanticModel',
+      workspaceId,
+    };
+
+    vi.mocked(fetch).mockResolvedValueOnce({
+      status: 200,
+      ok: true,
+      json: vi.fn().mockResolvedValueOnce(mockResponse),
+    } as any);
+
+    const result = await createSemanticModel(workspaceId, token, testOntology, lakehouseId);
+
+    expect(result).toEqual(mockResponse);
+    expect(fetch).toHaveBeenCalledWith(
+      `https://api.fabric.microsoft.com/v1/workspaces/${workspaceId}/semanticModels`,
+      expect.objectContaining({ method: 'POST' }),
+    );
+  });
+
+  // ─── Test 2: Non-OK response throws error ───────────────────────────────
+
+  it('throws error on non-OK response with status and body', async () => {
+    const errorBody = 'Unauthorized access';
+
+    vi.mocked(fetch).mockResolvedValueOnce({
+      status: 401,
+      ok: false,
+      text: vi.fn().mockResolvedValueOnce(errorBody),
+    } as any);
+
+    await expect(createSemanticModel(workspaceId, token, testOntology, lakehouseId)).rejects.toThrow(
+      'Failed to create semantic model: 401 Unauthorized access',
+    );
+  });
+
+  // ─── Test 3: 202 + poll → Succeeded → list fallback ─────────────────────
+
+  it('polls operation and returns found model on 202 success', async () => {
+    const mockModel = {
+      id: 'model-202',
+      displayName: 'TestOntology - Semantic Model',
+      description: 'Auto-generated semantic model for TestOntology ontology',
+      type: 'SemanticModel',
+      workspaceId,
+    };
+
+    // First call: 202 Accepted with operation ID
+    vi.mocked(fetch).mockResolvedValueOnce({
+      status: 202,
+      ok: true,
+      headers: { get: vi.fn((header: string) => (header === 'x-ms-operation-id' ? 'op-789' : null)) },
+    } as any);
+
+    // Poll call: operation status
+    vi.mocked(fetch).mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: vi.fn().mockResolvedValueOnce({ status: 'Succeeded' }),
+    } as any);
+
+    // List call: fetch created model
+    vi.mocked(fetch).mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: vi.fn().mockResolvedValueOnce({ value: [mockModel] }),
+    } as any);
+
+    const result = await createSemanticModel(workspaceId, token, testOntology, lakehouseId);
+
+    expect(result).toEqual(mockModel);
+    expect(fetch).toHaveBeenCalledTimes(3);
+  });
+
+  // ─── Test 4: 202 → not found throws error ──────────────────────────────
+
+  it('throws error when model created but not found after 202', async () => {
+    // First call: 202 Accepted with operation ID
+    vi.mocked(fetch).mockResolvedValueOnce({
+      status: 202,
+      ok: true,
+      headers: { get: vi.fn((header: string) => (header === 'x-ms-operation-id' ? 'op-789' : null)) },
+    } as any);
+
+    // Poll call: operation status
+    vi.mocked(fetch).mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: vi.fn().mockResolvedValueOnce({ status: 'Succeeded' }),
+    } as any);
+
+    // List call: empty list
+    vi.mocked(fetch).mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: vi.fn().mockResolvedValueOnce({ value: [] }),
+    } as any);
+
+    await expect(createSemanticModel(workspaceId, token, testOntology, lakehouseId)).rejects.toThrow(
+      'Semantic model created but not found',
+    );
+  });
+
+  // ─── Test 5: TMSL type mapping ──────────────────────────────────────────
+
+  it('verifies correct TMSL column types in model.bim payload', async () => {
+    const mockResponse = {
+      id: 'model-123',
+      displayName: 'TestOntology - Semantic Model',
+      description: 'Auto-generated semantic model for TestOntology ontology',
+      type: 'SemanticModel',
+      workspaceId,
+    };
+
+    let capturedDefinition: any;
+
+    vi.mocked(fetch).mockImplementationOnce(async (url, options) => {
+      if (typeof url === 'string' && url.includes('semanticModels')) {
+        capturedDefinition = JSON.parse((options as any).body);
+      }
+      return {
+        status: 200,
+        ok: true,
+        json: vi.fn().mockResolvedValueOnce(mockResponse),
+      } as any;
+    });
+
+    await createSemanticModel(workspaceId, token, testOntology, lakehouseId);
+
+    const modelPayload = extractModelPayload(capturedDefinition.definition.parts);
+    const model = (modelPayload as any).model;
+    const customerTable = model.tables.find((t: any) => t.name === 'Customer');
+
+    expect(customerTable).toBeDefined();
+    expect(customerTable.columns).toContainEqual(expect.objectContaining({ name: 'customerId', dataType: 'String' }));
+    expect(customerTable.columns).toContainEqual(expect.objectContaining({ name: 'age', dataType: 'Int64' }));
+    expect(customerTable.columns).toContainEqual(expect.objectContaining({ name: 'balance', dataType: 'Double' }));
+    expect(customerTable.columns).toContainEqual(expect.objectContaining({ name: 'active', dataType: 'Boolean' }));
+    expect(customerTable.columns).toContainEqual(expect.objectContaining({ name: 'created', dataType: 'DateTime' }));
+  });
+
+  // ─── Test 6: Identifier properties get isKey ────────────────────────────
+
+  it('sets isKey: true on identifier columns in model.bim', async () => {
+    const mockResponse = {
+      id: 'model-123',
+      displayName: 'TestOntology - Semantic Model',
+      description: 'Auto-generated semantic model for TestOntology ontology',
+      type: 'SemanticModel',
+      workspaceId,
+    };
+
+    let capturedDefinition: any;
+
+    vi.mocked(fetch).mockImplementationOnce(async (url, options) => {
+      if (typeof url === 'string' && url.includes('semanticModels')) {
+        capturedDefinition = JSON.parse((options as any).body);
+      }
+      return {
+        status: 200,
+        ok: true,
+        json: vi.fn().mockResolvedValueOnce(mockResponse),
+      } as any;
+    });
+
+    await createSemanticModel(workspaceId, token, testOntology, lakehouseId);
+
+    const modelPayload = extractModelPayload(capturedDefinition.definition.parts);
+    const model = (modelPayload as any).model;
+    const customerTable = model.tables.find((t: any) => t.name === 'Customer');
+    const customerIdColumn = customerTable.columns.find((c: any) => c.name === 'customerId');
+    const nameColumn = customerTable.columns.find((c: any) => c.name === 'name');
+
+    expect(customerIdColumn).toEqual(expect.objectContaining({ isKey: true }));
+    expect(nameColumn).not.toHaveProperty('isKey');
+  });
+
+  // ─── Test 7: Relationships built correctly ──────────────────────────────
+
+  it('builds relationships with correct fromTable, toTable, and join columns', async () => {
+    const mockResponse = {
+      id: 'model-123',
+      displayName: 'TestOntology - Semantic Model',
+      description: 'Auto-generated semantic model for TestOntology ontology',
+      type: 'SemanticModel',
+      workspaceId,
+    };
+
+    let capturedDefinition: any;
+
+    vi.mocked(fetch).mockImplementationOnce(async (url, options) => {
+      if (typeof url === 'string' && url.includes('semanticModels')) {
+        capturedDefinition = JSON.parse((options as any).body);
+      }
+      return {
+        status: 200,
+        ok: true,
+        json: vi.fn().mockResolvedValueOnce(mockResponse),
+      } as any;
+    });
+
+    await createSemanticModel(workspaceId, token, testOntology, lakehouseId);
+
+    const modelPayload = extractModelPayload(capturedDefinition.definition.parts);
+    const model = (modelPayload as any).model;
+
+    expect(model.relationships).toHaveLength(1);
+    const rel = model.relationships[0];
+    expect(rel).toEqual(expect.objectContaining({
+      fromTable: 'Customer',
+      fromColumn: 'customerId',
+      toTable: 'Order',
+      toColumn: 'orderId',
+      crossFilteringBehavior: 'OneDirection',
+    }));
+  });
+
+  // ─── Test 8: Missing entities in relationships skipped ──────────────────
+
+  it('skips relationships referencing non-existent entity IDs', async () => {
+    const invalidOntology: Ontology = {
+      name: 'InvalidOntology',
+      description: 'Ontology with invalid relationship',
+      entityTypes: [
+        {
+          id: 'customer',
+          name: 'Customer',
+          description: 'Customer entity',
+          icon: '👤',
+          color: '#fff',
+          properties: [
+            { name: 'customerId', type: 'string', isIdentifier: true },
+          ],
+        },
+      ],
+      relationships: [
+        // Reference to non-existent 'order' entity ID
+        { id: 'r1', name: 'places', from: 'customer', to: 'order', cardinality: '1:n' },
+      ],
+    };
+
+    const mockResponse = {
+      id: 'model-123',
+      displayName: 'InvalidOntology - Semantic Model',
+      description: 'Auto-generated semantic model for InvalidOntology ontology',
+      type: 'SemanticModel',
+      workspaceId,
+    };
+
+    let capturedDefinition: any;
+
+    vi.mocked(fetch).mockImplementationOnce(async (url, options) => {
+      if (typeof url === 'string' && url.includes('semanticModels')) {
+        capturedDefinition = JSON.parse((options as any).body);
+      }
+      return {
+        status: 200,
+        ok: true,
+        json: vi.fn().mockResolvedValueOnce(mockResponse),
+      } as any;
+    });
+
+    await createSemanticModel(workspaceId, token, invalidOntology, lakehouseId);
+
+    const modelPayload = extractModelPayload(capturedDefinition.definition.parts);
+    const model = (modelPayload as any).model;
+
+    // Relationship should not be included since 'order' entity doesn't exist
+    expect(model.relationships).toHaveLength(0);
+  });
+});

--- a/src/lib/fabricSemanticModel.ts
+++ b/src/lib/fabricSemanticModel.ts
@@ -1,0 +1,241 @@
+/**
+ * Fabric Semantic Model API client — creates Power BI semantic models
+ * from ontology definitions with Lakehouse bindings.
+ *
+ * API Reference:
+ *   https://learn.microsoft.com/en-us/rest/api/fabric/semanticmodel/items/create-semantic-model
+ */
+
+import type { Ontology, Property } from '../data/ontology';
+
+const FABRIC_API_BASE = 'https://api.fabric.microsoft.com/v1';
+
+export interface SemanticModelResponse {
+  id: string;
+  displayName: string;
+  description: string;
+  type: 'SemanticModel';
+  workspaceId: string;
+}
+
+// ─── TMSL Types ────────────────────────────────────────────────────────────
+
+interface TMSLColumn {
+  name: string;
+  dataType: string;
+  sourceColumn: string;
+  isKey?: boolean;
+}
+
+interface TMSLTable {
+  name: string;
+  columns: TMSLColumn[];
+  partitions: TMSLPartition[];
+}
+
+interface TMSLPartition {
+  name: string;
+  mode: string;
+  source: {
+    type: string;
+    expression: string[];
+  };
+}
+
+interface TMSLRelationship {
+  name: string;
+  fromTable: string;
+  fromColumn: string;
+  toTable: string;
+  toColumn: string;
+  crossFilteringBehavior: string;
+}
+
+interface TMSLModel {
+  defaultMode: string;
+  tables: TMSLTable[];
+  relationships: TMSLRelationship[];
+}
+
+// ─── Type Mapping ──────────────────────────────────────────────────────────
+
+function mapToTMSLType(propType: Property['type']): string {
+  switch (propType) {
+    case 'string': return 'String';
+    case 'integer': return 'Int64';
+    case 'decimal':
+    case 'double': return 'Double';
+    case 'boolean': return 'Boolean';
+    case 'date':
+    case 'datetime': return 'DateTime';
+    case 'enum': return 'String';
+    default: return 'String';
+  }
+}
+
+// ─── Conversion ────────────────────────────────────────────────────────────
+
+function toBase64(obj: unknown): string {
+  const json = JSON.stringify(obj, null, 2);
+  const bytes = new TextEncoder().encode(json);
+  let binary = '';
+  for (const b of bytes) {
+    binary += String.fromCharCode(b);
+  }
+  return btoa(binary);
+}
+
+/**
+ * Build TMSL model definition from an ontology.
+ */
+function buildTMSLModel(
+  ontology: Ontology,
+  lakehouseWorkspaceId: string,
+  lakehouseId: string,
+): TMSLModel {
+  const tables: TMSLTable[] = ontology.entityTypes.map(entity => {
+    const columns: TMSLColumn[] = entity.properties.map(prop => ({
+      name: prop.name,
+      dataType: mapToTMSLType(prop.type),
+      sourceColumn: prop.name,
+      ...(prop.isIdentifier ? { isKey: true } : {}),
+    }));
+
+    return {
+      name: entity.name,
+      columns,
+      partitions: [{
+        name: `${entity.name}-partition`,
+        mode: 'DirectLake',
+        source: {
+          type: 'Entity',
+          expression: [
+            `DatabaseQuery`,
+            `FROM [${lakehouseWorkspaceId}].[${lakehouseId}].[dbo].[${entity.name}]`,
+          ],
+        },
+      }],
+    };
+  });
+
+  // Build relationships from ontology
+  const relationships: TMSLRelationship[] = [];
+  for (const rel of ontology.relationships) {
+    const fromEntity = ontology.entityTypes.find(e => e.id === rel.from);
+    const toEntity = ontology.entityTypes.find(e => e.id === rel.to);
+    if (!fromEntity || !toEntity) continue;
+
+    // Use identifier properties as join columns
+    const fromIdProp = fromEntity.properties.find(p => p.isIdentifier) ?? fromEntity.properties[0];
+    const toIdProp = toEntity.properties.find(p => p.isIdentifier) ?? toEntity.properties[0];
+    if (!fromIdProp || !toIdProp) continue;
+
+    relationships.push({
+      name: `${fromEntity.name}_${rel.name}_${toEntity.name}`,
+      fromTable: fromEntity.name,
+      fromColumn: fromIdProp.name,
+      toTable: toEntity.name,
+      toColumn: toIdProp.name,
+      crossFilteringBehavior: 'OneDirection',
+    });
+  }
+
+  return {
+    defaultMode: 'DirectLake',
+    tables,
+    relationships,
+  };
+}
+
+// ─── Fabric API helpers ────────────────────────────────────────────────────
+
+async function pollOperation(operationId: string, token: string): Promise<void> {
+  for (let i = 0; i < 60; i++) {
+    await new Promise(resolve => setTimeout(resolve, 3000));
+    const res = await fetch(`${FABRIC_API_BASE}/operations/${operationId}`, {
+      headers: { 'Authorization': `Bearer ${token}` },
+    });
+    if (res.ok) {
+      const body = await res.json();
+      if (body.status === 'Succeeded') return;
+      if (body.status === 'Failed') {
+        throw new Error(`Operation failed: ${body.error?.message ?? 'Unknown'}`);
+      }
+    }
+  }
+  throw new Error('Semantic model creation timed out');
+}
+
+/**
+ * Create a Power BI Semantic Model from an ontology, bound to a Lakehouse.
+ */
+export async function createSemanticModel(
+  workspaceId: string,
+  token: string,
+  ontology: Ontology,
+  lakehouseId: string,
+): Promise<SemanticModelResponse> {
+  const model = buildTMSLModel(ontology, workspaceId, lakehouseId);
+
+  const definition = {
+    parts: [
+      {
+        path: '.platform',
+        payload: toBase64({
+          metadata: {
+            type: 'SemanticModel',
+            displayName: `${ontology.name} - Semantic Model`,
+          },
+        }),
+        payloadType: 'InlineBase64',
+      },
+      {
+        path: 'definition/model.bim',
+        payload: toBase64({ model }),
+        payloadType: 'InlineBase64',
+      },
+    ],
+  };
+
+  const res = await fetch(
+    `${FABRIC_API_BASE}/workspaces/${workspaceId}/semanticModels`,
+    {
+      method: 'POST',
+      headers: {
+        'Authorization': `Bearer ${token}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        displayName: `${ontology.name} - Semantic Model`,
+        description: `Auto-generated semantic model for ${ontology.name} ontology`,
+        definition,
+      }),
+    },
+  );
+
+  if (res.status === 202) {
+    const opId = res.headers.get('x-ms-operation-id');
+    if (opId) await pollOperation(opId, token);
+
+    // Fetch created model
+    const listRes = await fetch(
+      `${FABRIC_API_BASE}/workspaces/${workspaceId}/semanticModels`,
+      { headers: { 'Authorization': `Bearer ${token}` } },
+    );
+    if (listRes.ok) {
+      const list = await listRes.json();
+      const found = list.value?.find(
+        (m: SemanticModelResponse) => m.displayName === `${ontology.name} - Semantic Model`,
+      );
+      if (found) return found;
+    }
+    throw new Error('Semantic model created but not found');
+  }
+
+  if (!res.ok) {
+    const body = await res.text();
+    throw new Error(`Failed to create semantic model: ${res.status} ${body}`);
+  }
+
+  return await res.json() as SemanticModelResponse;
+}

--- a/src/lib/fabricWorkspace.test.ts
+++ b/src/lib/fabricWorkspace.test.ts
@@ -1,0 +1,218 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import {
+  listWorkspaces,
+  listCapacities,
+  assignCapacity,
+  createWorkspace,
+  FabricWorkspace,
+  FabricCapacity,
+} from './fabricWorkspace';
+
+// ─── Helpers ────────────────────────────────────────────────────────────────
+
+const mockResponse = (body: unknown, status = 200) => ({
+  ok: status >= 200 && status < 300,
+  status,
+  json: () => Promise.resolve(body),
+  text: () => Promise.resolve(JSON.stringify(body)),
+});
+
+// ─── listWorkspaces ─────────────────────────────────────────────────────────
+
+describe('listWorkspaces', () => {
+  beforeEach(() => {
+    vi.stubGlobal('fetch', vi.fn());
+  });
+  afterEach(() => vi.restoreAllMocks());
+
+  it('returns workspaces sorted alphabetically by displayName', async () => {
+    const workspaces = [
+      { id: '1', displayName: 'Zebra', description: '', type: 'Workspace' },
+      { id: '2', displayName: 'Alpha', description: '', type: 'Workspace' },
+      { id: '3', displayName: 'Beta', description: '', type: 'Workspace' },
+    ];
+
+    (fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce(
+      mockResponse({ value: workspaces }),
+    );
+
+    const result = await listWorkspaces('test-token');
+
+    expect(result).toHaveLength(3);
+    expect(result[0].displayName).toBe('Alpha');
+    expect(result[1].displayName).toBe('Beta');
+    expect(result[2].displayName).toBe('Zebra');
+  });
+
+  it('handles multi-page pagination (continuationUri)', async () => {
+    const page1 = [
+      { id: '1', displayName: 'Workspace A', description: '', type: 'Workspace' },
+    ];
+    const page2 = [
+      { id: '2', displayName: 'Workspace B', description: '', type: 'Workspace' },
+    ];
+
+    (fetch as ReturnType<typeof vi.fn>)
+      .mockResolvedValueOnce(
+        mockResponse({
+          value: page1,
+          continuationUri: 'https://api.fabric.microsoft.com/v1/workspaces?page=2',
+        }),
+      )
+      .mockResolvedValueOnce(
+        mockResponse({
+          value: page2,
+        }),
+      );
+
+    const result = await listWorkspaces('test-token');
+
+    expect(result).toHaveLength(2);
+    expect(result[0].displayName).toBe('Workspace A');
+    expect(result[1].displayName).toBe('Workspace B');
+    expect(fetch).toHaveBeenCalledTimes(2);
+  });
+
+  it('throws on non-OK response', async () => {
+    (fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce(
+      mockResponse({ error: 'Unauthorized' }, 401),
+    );
+
+    await expect(listWorkspaces('bad-token')).rejects.toThrow(
+      'Failed to list workspaces',
+    );
+  });
+});
+
+// ─── listCapacities ─────────────────────────────────────────────────────────
+
+describe('listCapacities', () => {
+  beforeEach(() => {
+    vi.stubGlobal('fetch', vi.fn());
+  });
+  afterEach(() => vi.restoreAllMocks());
+
+  it('returns only Active capacities', async () => {
+    const capacities = [
+      { id: '1', displayName: 'Capacity A', sku: 'F2', state: 'Active', region: 'US' },
+      { id: '2', displayName: 'Capacity B', sku: 'F4', state: 'Deleted', region: 'US' },
+      { id: '3', displayName: 'Capacity C', sku: 'P1', state: 'Active', region: 'EU' },
+    ];
+
+    (fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce(
+      mockResponse({ value: capacities }),
+    );
+
+    const result = await listCapacities('test-token');
+
+    expect(result).toHaveLength(2);
+    expect(result[0].displayName).toBe('Capacity A');
+    expect(result[1].displayName).toBe('Capacity C');
+    expect(result.every(c => c.state === 'Active')).toBe(true);
+  });
+
+  it('returns empty array on non-OK response', async () => {
+    (fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce(
+      mockResponse({ error: 'Forbidden' }, 403),
+    );
+
+    const result = await listCapacities('test-token');
+
+    expect(result).toEqual([]);
+  });
+});
+
+// ─── assignCapacity ─────────────────────────────────────────────────────────
+
+describe('assignCapacity', () => {
+  beforeEach(() => {
+    vi.stubGlobal('fetch', vi.fn());
+  });
+  afterEach(() => vi.restoreAllMocks());
+
+  it('sends correct POST body', async () => {
+    (fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce(
+      mockResponse({}),
+    );
+
+    await assignCapacity('test-token', 'workspace-123', 'capacity-456');
+
+    expect(fetch).toHaveBeenCalledWith(
+      expect.stringContaining('/workspaces/workspace-123/assignToCapacity'),
+      expect.objectContaining({
+        method: 'POST',
+        headers: expect.objectContaining({
+          'Authorization': 'Bearer test-token',
+          'Content-Type': 'application/json',
+        }),
+        body: JSON.stringify({ capacityId: 'capacity-456' }),
+      }),
+    );
+  });
+
+  it('throws on failure', async () => {
+    (fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce(
+      mockResponse({ error: 'Bad Request' }, 400),
+    );
+
+    await expect(
+      assignCapacity('test-token', 'workspace-123', 'capacity-456'),
+    ).rejects.toThrow('Failed to assign capacity');
+  });
+});
+
+// ─── createWorkspace ────────────────────────────────────────────────────────
+
+describe('createWorkspace', () => {
+  beforeEach(() => {
+    vi.stubGlobal('fetch', vi.fn());
+  });
+  afterEach(() => vi.restoreAllMocks());
+
+  it('returns created workspace', async () => {
+    const createdWorkspace: FabricWorkspace = {
+      id: 'new-ws-123',
+      displayName: 'My New Workspace',
+      description: 'A test workspace',
+      type: 'Workspace',
+    };
+
+    (fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce(
+      mockResponse(createdWorkspace),
+    );
+
+    const result = await createWorkspace(
+      'test-token',
+      'My New Workspace',
+      'A test workspace',
+    );
+
+    expect(result.id).toBe('new-ws-123');
+    expect(result.displayName).toBe('My New Workspace');
+    expect(result.description).toBe('A test workspace');
+    expect(fetch).toHaveBeenCalledWith(
+      expect.stringContaining('/workspaces'),
+      expect.objectContaining({
+        method: 'POST',
+        headers: expect.objectContaining({
+          'Authorization': 'Bearer test-token',
+          'Content-Type': 'application/json',
+        }),
+        body: JSON.stringify({
+          displayName: 'My New Workspace',
+          description: 'A test workspace',
+        }),
+      }),
+    );
+  });
+
+  it('throws on failure', async () => {
+    (fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce(
+      mockResponse({ error: 'Internal Server Error' }, 500),
+    );
+
+    await expect(
+      createWorkspace('test-token', 'My Workspace'),
+    ).rejects.toThrow('Failed to create workspace');
+  });
+});

--- a/src/lib/fabricWorkspace.ts
+++ b/src/lib/fabricWorkspace.ts
@@ -1,0 +1,121 @@
+/**
+ * Fabric Workspace API client — list workspaces and create new ones.
+ *
+ * API Reference:
+ *   https://learn.microsoft.com/en-us/rest/api/fabric/core/workspaces/list-workspaces
+ *   https://learn.microsoft.com/en-us/rest/api/fabric/core/workspaces/create-workspace
+ */
+
+const FABRIC_API_BASE = 'https://api.fabric.microsoft.com/v1';
+
+export interface FabricWorkspace {
+  id: string;
+  displayName: string;
+  description: string;
+  type: string;
+  capacityId?: string;
+  capacityRegion?: string;
+}
+
+export interface FabricCapacity {
+  id: string;
+  displayName: string;
+  sku: string;
+  state: string;
+  region: string;
+}
+
+interface ListWorkspacesResponse {
+  value: FabricWorkspace[];
+  continuationUri?: string;
+}
+
+interface ListCapacitiesResponse {
+  value: FabricCapacity[];
+}
+
+/**
+ * List all Fabric workspaces the current user has access to.
+ */
+export async function listWorkspaces(token: string): Promise<FabricWorkspace[]> {
+  const workspaces: FabricWorkspace[] = [];
+  let url: string | null = `${FABRIC_API_BASE}/workspaces`;
+
+  while (url) {
+    const res = await fetch(url, {
+      headers: { 'Authorization': `Bearer ${token}` },
+    });
+
+    if (!res.ok) {
+      const body = await res.text();
+      throw new Error(`Failed to list workspaces: ${res.status} ${body}`);
+    }
+
+    const data: ListWorkspacesResponse = await res.json();
+    workspaces.push(...data.value);
+    url = data.continuationUri ?? null;
+  }
+
+  // Sort alphabetically
+  workspaces.sort((a, b) => a.displayName.localeCompare(b.displayName));
+  return workspaces;
+}
+
+/**
+ * List available Fabric capacities.
+ */
+export async function listCapacities(token: string): Promise<FabricCapacity[]> {
+  const res = await fetch(`${FABRIC_API_BASE}/capacities`, {
+    headers: { 'Authorization': `Bearer ${token}` },
+  });
+  if (!res.ok) return [];
+  const data: ListCapacitiesResponse = await res.json();
+  return data.value.filter(c => c.state === 'Active');
+}
+
+/**
+ * Assign a capacity to a workspace.
+ */
+export async function assignCapacity(
+  token: string,
+  workspaceId: string,
+  capacityId: string,
+): Promise<void> {
+  const res = await fetch(`${FABRIC_API_BASE}/workspaces/${workspaceId}/assignToCapacity`, {
+    method: 'POST',
+    headers: {
+      'Authorization': `Bearer ${token}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({ capacityId }),
+  });
+  if (!res.ok) {
+    const body = await res.text();
+    throw new Error(`Failed to assign capacity: ${res.status} ${body}`);
+  }
+}
+
+/**
+ * Create a new Fabric workspace.
+ */
+export async function createWorkspace(
+  token: string,
+  displayName: string,
+  description = '',
+): Promise<FabricWorkspace> {
+  const res = await fetch(`${FABRIC_API_BASE}/workspaces`, {
+    method: 'POST',
+    headers: {
+      'Authorization': `Bearer ${token}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({ displayName, description }),
+  });
+
+  if (!res.ok) {
+    const body = await res.text();
+    throw new Error(`Failed to create workspace: ${res.status} ${body}`);
+  }
+
+  return await res.json() as FabricWorkspace;
+}

--- a/src/lib/msalAuth.test.ts
+++ b/src/lib/msalAuth.test.ts
@@ -1,0 +1,632 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+// Mock MSAL module before any imports
+const mockInstance = {
+  initialize: vi.fn().mockResolvedValue(undefined),
+  handleRedirectPromise: vi.fn().mockResolvedValue(null),
+  getActiveAccount: vi.fn().mockReturnValue(null),
+  getAllAccounts: vi.fn().mockReturnValue([]),
+  setActiveAccount: vi.fn(),
+  acquireTokenSilent: vi.fn(),
+  acquireTokenRedirect: vi.fn().mockResolvedValue(undefined),
+  logoutPopup: vi.fn().mockResolvedValue(undefined),
+};
+
+vi.mock('@azure/msal-browser', () => ({
+  PublicClientApplication: vi.fn(function MockPCA() {
+    return mockInstance;
+  }),
+  InteractionRequiredAuthError: class extends Error {
+    name = 'InteractionRequiredAuthError';
+  },
+  BrowserAuthError: class extends Error {
+    errorCode: string;
+    constructor(code: string) {
+      super(code);
+      this.errorCode = code;
+      this.name = 'BrowserAuthError';
+    }
+  },
+}));
+
+// Mock import.meta.env for VITE_FABRIC_CLIENT_ID (Vitest)
+// Tests that exercise sign-in code paths require a configured client ID.
+vi.stubEnv('VITE_FABRIC_CLIENT_ID', 'test-client-id');
+
+// Mock window.location
+const originalLocation = window.location;
+delete (window as any).location;
+window.location = {
+  ...originalLocation,
+  hostname: 'localhost',
+  origin: 'http://localhost:5173',
+  hash: '',
+} as any;
+
+describe('msalAuth', () => {
+  let msalAuth: typeof import('./msalAuth');
+
+  beforeEach(async () => {
+    vi.resetModules();
+    
+    // Reset all mock state
+    Object.values(mockInstance).forEach((m) => {
+      if (typeof m === 'object' && m !== null && 'mockClear' in m) {
+        m.mockClear?.();
+      }
+    });
+
+    // Reset mock return values to defaults
+    mockInstance.initialize.mockResolvedValue(undefined);
+    mockInstance.handleRedirectPromise.mockResolvedValue(null);
+    mockInstance.getActiveAccount.mockReturnValue(null);
+    mockInstance.getAllAccounts.mockReturnValue([]);
+    mockInstance.acquireTokenSilent.mockClear();
+    mockInstance.acquireTokenRedirect.mockResolvedValue(undefined);
+    mockInstance.logoutPopup.mockResolvedValue(undefined);
+
+    // Clear sessionStorage between tests
+    sessionStorage.clear();
+
+    // Reset window.location.hash
+    window.location.hash = '';
+
+    // Dynamically import the module
+    msalAuth = await import('./msalAuth');
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+    sessionStorage.clear();
+  });
+
+  describe('isMsalConfigured / isLocalhostWithDefaultClient', () => {
+    it('isMsalConfigured returns true when VITE_FABRIC_CLIENT_ID is set', () => {
+      expect(msalAuth.isMsalConfigured()).toBe(true);
+    });
+
+    it('isMsalConfigured returns false when VITE_FABRIC_CLIENT_ID is empty', async () => {
+      vi.stubEnv('VITE_FABRIC_CLIENT_ID', '');
+      vi.resetModules();
+      const reloaded = await import('./msalAuth');
+      expect(reloaded.isMsalConfigured()).toBe(false);
+      vi.stubEnv('VITE_FABRIC_CLIENT_ID', 'test-client-id');
+    });
+
+    it('isLocalhostWithDefaultClient returns false on localhost when MSAL is configured', () => {
+      const result = msalAuth.isLocalhostWithDefaultClient();
+      expect(result).toBe(false);
+    });
+
+    it('returns false on non-localhost', async () => {
+      window.location.hostname = 'example.com';
+      vi.resetModules();
+      msalAuth = await import('./msalAuth');
+      const result = msalAuth.isLocalhostWithDefaultClient();
+      expect(result).toBe(false);
+    });
+  });
+
+  describe('consumeRedirectResult', () => {
+    it('returns null when no redirect happened', async () => {
+      mockInstance.handleRedirectPromise.mockResolvedValue(null);
+      const result = await msalAuth.consumeRedirectResult();
+      expect(result).toBeNull();
+    });
+
+    it('returns auth result when redirect completed, then null on second call', async () => {
+      const mockAuthResult = {
+        accessToken: 'mock-token',
+        account: {
+          name: 'Test User',
+          username: 'test@example.com',
+          homeAccountId: 'home-id',
+          environment: 'login.microsoftonline.com',
+          tenantId: 'tenant-id',
+          localAccountId: 'local-id',
+        },
+        expiresOn: new Date(),
+        scopes: [],
+        tokenType: 'Bearer',
+      };
+
+      mockInstance.handleRedirectPromise.mockResolvedValue(mockAuthResult);
+
+      // First call should return the result
+      const firstResult = await msalAuth.consumeRedirectResult();
+      expect(firstResult).not.toBeNull();
+      expect(firstResult?.accessToken).toBe('mock-token');
+      expect(firstResult?.account.name).toBe('Test User');
+      expect(firstResult?.account.username).toBe('test@example.com');
+
+      // Second call should return null (result was consumed)
+      const secondResult = await msalAuth.consumeRedirectResult();
+      expect(secondResult).toBeNull();
+    });
+  });
+
+  describe('hasPendingDeployIntent', () => {
+    it('returns false when deploy intent not set', () => {
+      const result = msalAuth.hasPendingDeployIntent();
+      expect(result).toBe(false);
+    });
+
+    it('returns true when deploy intent is set', () => {
+      sessionStorage.setItem('fabric_deploy_pending', 'true');
+      const result = msalAuth.hasPendingDeployIntent();
+      expect(result).toBe(true);
+    });
+
+    it('returns false when deploy intent is not "true"', () => {
+      sessionStorage.setItem('fabric_deploy_pending', 'false');
+      const result = msalAuth.hasPendingDeployIntent();
+      expect(result).toBe(false);
+    });
+  });
+
+  describe('clearDeployIntent', () => {
+    it('clears deploy intent and restores hash route', () => {
+      sessionStorage.setItem('fabric_deploy_pending', 'true');
+      sessionStorage.setItem('fabric_deploy_hash', '#/workspace/123');
+      window.location.hash = '';
+
+      msalAuth.clearDeployIntent();
+
+      expect(sessionStorage.getItem('fabric_deploy_pending')).toBeNull();
+      expect(sessionStorage.getItem('fabric_deploy_hash')).toBeNull();
+      expect(window.location.hash).toBe('#/workspace/123');
+    });
+
+    it('clears deploy intent without changing hash if it matches', () => {
+      sessionStorage.setItem('fabric_deploy_pending', 'true');
+      sessionStorage.setItem('fabric_deploy_hash', '#/workspace/123');
+      window.location.hash = '#/workspace/123';
+
+      msalAuth.clearDeployIntent();
+
+      expect(sessionStorage.getItem('fabric_deploy_pending')).toBeNull();
+      expect(sessionStorage.getItem('fabric_deploy_hash')).toBeNull();
+      expect(window.location.hash).toBe('#/workspace/123');
+    });
+
+    it('clears deploy intent even if hash is not set', () => {
+      sessionStorage.setItem('fabric_deploy_pending', 'true');
+
+      msalAuth.clearDeployIntent();
+
+      expect(sessionStorage.getItem('fabric_deploy_pending')).toBeNull();
+      expect(sessionStorage.getItem('fabric_deploy_hash')).toBeNull();
+    });
+  });
+
+  describe('acquireFabricToken', () => {
+    it('returns token from silent acquisition when accounts exist', async () => {
+      const mockAccount = {
+        name: 'Test User',
+        username: 'test@example.com',
+        homeAccountId: 'home-id',
+        environment: 'login.microsoftonline.com',
+        tenantId: 'tenant-id',
+        localAccountId: 'local-id',
+      };
+
+      const mockAuthResult = {
+        accessToken: 'fabric-token',
+        account: mockAccount,
+        expiresOn: new Date(),
+        scopes: [],
+        tokenType: 'Bearer',
+      };
+
+      mockInstance.getAllAccounts.mockReturnValue([mockAccount]);
+      mockInstance.acquireTokenSilent.mockResolvedValue(mockAuthResult);
+
+      const result = await msalAuth.acquireFabricToken();
+
+      expect(result.accessToken).toBe('fabric-token');
+      expect(result.account.name).toBe('Test User');
+      expect(result.account.username).toBe('test@example.com');
+      expect(mockInstance.acquireTokenSilent).toHaveBeenCalledWith(
+        expect.objectContaining({
+          scopes: [
+            'https://api.fabric.microsoft.com/Workspace.ReadWrite.All',
+            'https://api.fabric.microsoft.com/Item.ReadWrite.All',
+          ],
+          account: mockAccount,
+        })
+      );
+    });
+
+    it('throws when no accounts exist and calls signInWithRedirect', async () => {
+      mockInstance.getAllAccounts.mockReturnValue([]);
+
+      await expect(msalAuth.acquireFabricToken()).rejects.toThrow(
+        'No signed-in account. Redirecting to sign in…'
+      );
+
+      expect(mockInstance.acquireTokenRedirect).toHaveBeenCalled();
+    });
+
+    it('throws and redirects when InteractionRequiredAuthError is caught', async () => {
+      const mockAccount = {
+        name: 'Test User',
+        username: 'test@example.com',
+        homeAccountId: 'home-id',
+        environment: 'login.microsoftonline.com',
+        tenantId: 'tenant-id',
+        localAccountId: 'local-id',
+      };
+
+      mockInstance.getAllAccounts.mockReturnValue([mockAccount]);
+
+      // Dynamically import InteractionRequiredAuthError from the mock
+      const { InteractionRequiredAuthError } = await import('@azure/msal-browser');
+      mockInstance.acquireTokenSilent.mockRejectedValue(
+        new InteractionRequiredAuthError('interaction_required', 'Interaction required')
+      );
+
+      await expect(msalAuth.acquireFabricToken()).rejects.toThrow(
+        'Redirecting for re-authentication…'
+      );
+
+      expect(mockInstance.acquireTokenRedirect).toHaveBeenCalled();
+    });
+
+    it('sets active account after successful token acquisition', async () => {
+      const mockAccount = {
+        name: 'Test User',
+        username: 'test@example.com',
+        homeAccountId: 'home-id',
+        environment: 'login.microsoftonline.com',
+        tenantId: 'tenant-id',
+        localAccountId: 'local-id',
+      };
+
+      const mockAuthResult = {
+        accessToken: 'fabric-token',
+        account: mockAccount,
+        expiresOn: new Date(),
+        scopes: [],
+        tokenType: 'Bearer',
+      };
+
+      mockInstance.getAllAccounts.mockReturnValue([mockAccount]);
+      mockInstance.acquireTokenSilent.mockResolvedValue(mockAuthResult);
+
+      await msalAuth.acquireFabricToken();
+
+      expect(mockInstance.setActiveAccount).toHaveBeenCalledWith(mockAccount);
+    });
+  });
+
+  describe('acquireOneLakeToken', () => {
+    it('returns token from silent acquisition when accounts exist', async () => {
+      const mockAccount = {
+        name: 'Test User',
+        username: 'test@example.com',
+        homeAccountId: 'home-id',
+        environment: 'login.microsoftonline.com',
+        tenantId: 'tenant-id',
+        localAccountId: 'local-id',
+      };
+
+      const mockAuthResult = {
+        accessToken: 'onelake-token',
+        account: mockAccount,
+        expiresOn: new Date(),
+        scopes: [],
+        tokenType: 'Bearer',
+      };
+
+      mockInstance.getAllAccounts.mockReturnValue([mockAccount]);
+      mockInstance.acquireTokenSilent.mockResolvedValue(mockAuthResult);
+
+      const result = await msalAuth.acquireOneLakeToken();
+
+      expect(result.accessToken).toBe('onelake-token');
+      expect(result.account.name).toBe('Test User');
+      expect(mockInstance.acquireTokenSilent).toHaveBeenCalledWith(
+        expect.objectContaining({
+          scopes: ['https://storage.azure.com/user_impersonation'],
+          account: mockAccount,
+        })
+      );
+    });
+
+    it('throws with consent message on InteractionRequiredAuthError (does NOT redirect)', async () => {
+      const mockAccount = {
+        name: 'Test User',
+        username: 'test@example.com',
+        homeAccountId: 'home-id',
+        environment: 'login.microsoftonline.com',
+        tenantId: 'tenant-id',
+        localAccountId: 'local-id',
+      };
+
+      mockInstance.getAllAccounts.mockReturnValue([mockAccount]);
+
+      const { InteractionRequiredAuthError } = await import('@azure/msal-browser');
+      mockInstance.acquireTokenSilent.mockRejectedValue(
+        new InteractionRequiredAuthError('interaction_required', 'Interaction required')
+      );
+
+      await expect(msalAuth.acquireOneLakeToken()).rejects.toThrow(
+        'OneLake consent required. Please sign out and sign back in to grant storage permissions, then retry.'
+      );
+
+      // Verify that redirects were NOT called
+      expect(mockInstance.acquireTokenRedirect).not.toHaveBeenCalled();
+    });
+
+    it('throws when no accounts exist', async () => {
+      mockInstance.getAllAccounts.mockReturnValue([]);
+
+      await expect(msalAuth.acquireOneLakeToken()).rejects.toThrow(
+        'No signed-in account. Please sign in first.'
+      );
+    });
+
+    it('rethrows other errors', async () => {
+      const mockAccount = {
+        name: 'Test User',
+        username: 'test@example.com',
+        homeAccountId: 'home-id',
+        environment: 'login.microsoftonline.com',
+        tenantId: 'tenant-id',
+        localAccountId: 'local-id',
+      };
+
+      mockInstance.getAllAccounts.mockReturnValue([mockAccount]);
+      const customError = new Error('Network error');
+      mockInstance.acquireTokenSilent.mockRejectedValue(customError);
+
+      await expect(msalAuth.acquireOneLakeToken()).rejects.toThrow('Network error');
+    });
+  });
+
+  describe('isPopupError', () => {
+    it('identifies popup_window_error as popup error', async () => {
+      const { BrowserAuthError } = await import('@azure/msal-browser');
+      const err = new BrowserAuthError('popup_window_error');
+      expect(msalAuth.isPopupError(err)).toBe(true);
+    });
+
+    it('identifies monitor_window_timeout as popup error', async () => {
+      const { BrowserAuthError } = await import('@azure/msal-browser');
+      const err = new BrowserAuthError('monitor_window_timeout');
+      expect(msalAuth.isPopupError(err)).toBe(true);
+    });
+
+    it('identifies empty_window_error as popup error', async () => {
+      const { BrowserAuthError } = await import('@azure/msal-browser');
+      const err = new BrowserAuthError('empty_window_error');
+      expect(msalAuth.isPopupError(err)).toBe(true);
+    });
+
+    it('identifies user_cancelled as popup error', async () => {
+      const { BrowserAuthError } = await import('@azure/msal-browser');
+      const err = new BrowserAuthError('user_cancelled');
+      expect(msalAuth.isPopupError(err)).toBe(true);
+    });
+
+    it('returns false for non-popup BrowserAuthError', async () => {
+      const { BrowserAuthError } = await import('@azure/msal-browser');
+      const err = new BrowserAuthError('some_other_error');
+      expect(msalAuth.isPopupError(err)).toBe(false);
+    });
+
+    it('identifies Error with "timed_out" message as popup error', () => {
+      const err = new Error('Request timed_out');
+      expect(msalAuth.isPopupError(err)).toBe(true);
+    });
+
+    it('identifies Error with "popup" message as popup error', () => {
+      const err = new Error('Popup blocked');
+      expect(msalAuth.isPopupError(err)).toBe(true);
+    });
+
+    it('identifies Error with "blocked" message as popup error', () => {
+      const err = new Error('Window blocked');
+      expect(msalAuth.isPopupError(err)).toBe(true);
+    });
+
+    it('returns false for non-popup Error', () => {
+      const err = new Error('Some other error');
+      expect(msalAuth.isPopupError(err)).toBe(false);
+    });
+
+    it('returns false for non-Error values', () => {
+      expect(msalAuth.isPopupError('string error')).toBe(false);
+      expect(msalAuth.isPopupError(null)).toBe(false);
+      expect(msalAuth.isPopupError(undefined)).toBe(false);
+    });
+  });
+
+  describe('signOut', () => {
+    it('calls logoutPopup with active account', async () => {
+      const mockAccount = {
+        name: 'Test User',
+        username: 'test@example.com',
+        homeAccountId: 'home-id',
+        environment: 'login.microsoftonline.com',
+        tenantId: 'tenant-id',
+        localAccountId: 'local-id',
+      };
+
+      mockInstance.getActiveAccount.mockReturnValue(mockAccount);
+
+      await msalAuth.signOut();
+
+      expect(mockInstance.logoutPopup).toHaveBeenCalledWith({
+        account: mockAccount,
+      });
+    });
+
+    it('calls logoutPopup with first account if no active account', async () => {
+      const mockAccount = {
+        name: 'Test User',
+        username: 'test@example.com',
+        homeAccountId: 'home-id',
+        environment: 'login.microsoftonline.com',
+        tenantId: 'tenant-id',
+        localAccountId: 'local-id',
+      };
+
+      mockInstance.getActiveAccount.mockReturnValue(null);
+      mockInstance.getAllAccounts.mockReturnValue([mockAccount]);
+
+      await msalAuth.signOut();
+
+      expect(mockInstance.logoutPopup).toHaveBeenCalledWith({
+        account: mockAccount,
+      });
+    });
+
+    it('does not call logoutPopup if no accounts exist', async () => {
+      mockInstance.getActiveAccount.mockReturnValue(null);
+      mockInstance.getAllAccounts.mockReturnValue([]);
+
+      await msalAuth.signOut();
+
+      expect(mockInstance.logoutPopup).not.toHaveBeenCalled();
+    });
+
+    it('resets initPromise after logout', async () => {
+      const mockAccount = {
+        name: 'Test User',
+        username: 'test@example.com',
+        homeAccountId: 'home-id',
+        environment: 'login.microsoftonline.com',
+        tenantId: 'tenant-id',
+        localAccountId: 'local-id',
+      };
+
+      mockInstance.getActiveAccount.mockReturnValue(mockAccount);
+
+      // First call should initialize
+      await msalAuth.signOut();
+
+      // Reset mocks to track the next initialization
+      mockInstance.initialize.mockClear();
+
+      // Call getInstance again - should reinitialize
+      // We need to trigger this through another function that uses getInstance
+      mockInstance.getAllAccounts.mockReturnValue([]);
+      try {
+        await msalAuth.acquireFabricToken();
+      } catch {
+        // Expected to throw
+      }
+
+      // Verify initialize was called again
+      expect(mockInstance.initialize).toHaveBeenCalled();
+    });
+  });
+
+  describe('signInWithRedirect', () => {
+    it('sets deploy intent and hash, then calls acquireTokenRedirect', async () => {
+      window.location.hash = '#/workspace/123';
+
+      await msalAuth.signInWithRedirect();
+
+      expect(sessionStorage.getItem('fabric_deploy_pending')).toBe('true');
+      expect(sessionStorage.getItem('fabric_deploy_hash')).toBe('#/workspace/123');
+      expect(mockInstance.acquireTokenRedirect).toHaveBeenCalledWith({
+        scopes: [
+          'https://api.fabric.microsoft.com/Workspace.ReadWrite.All',
+          'https://api.fabric.microsoft.com/Item.ReadWrite.All',
+        ],
+        extraScopesToConsent: ['https://storage.azure.com/user_impersonation'],
+      });
+    });
+
+    it('saves empty hash if no hash route', async () => {
+      window.location.hash = '';
+
+      await msalAuth.signInWithRedirect();
+
+      expect(sessionStorage.getItem('fabric_deploy_pending')).toBe('true');
+      expect(sessionStorage.getItem('fabric_deploy_hash')).toBe('');
+    });
+  });
+
+  describe('getSignedInAccount', () => {
+    it('returns active account if signed in', async () => {
+      const mockAccount = {
+        name: 'Test User',
+        username: 'test@example.com',
+        homeAccountId: 'home-id',
+        environment: 'login.microsoftonline.com',
+        tenantId: 'tenant-id',
+        localAccountId: 'local-id',
+      };
+
+      mockInstance.getActiveAccount.mockReturnValue(mockAccount);
+
+      const result = await msalAuth.getSignedInAccount();
+
+      expect(result).toEqual({
+        name: 'Test User',
+        username: 'test@example.com',
+      });
+    });
+
+    it('returns first account if no active account', async () => {
+      const mockAccount = {
+        name: 'Test User',
+        username: 'test@example.com',
+        homeAccountId: 'home-id',
+        environment: 'login.microsoftonline.com',
+        tenantId: 'tenant-id',
+        localAccountId: 'local-id',
+      };
+
+      mockInstance.getActiveAccount.mockReturnValue(null);
+      mockInstance.getAllAccounts.mockReturnValue([mockAccount]);
+
+      const result = await msalAuth.getSignedInAccount();
+
+      expect(result).toEqual({
+        name: 'Test User',
+        username: 'test@example.com',
+      });
+    });
+
+    it('returns null if no accounts', async () => {
+      mockInstance.getActiveAccount.mockReturnValue(null);
+      mockInstance.getAllAccounts.mockReturnValue([]);
+
+      const result = await msalAuth.getSignedInAccount();
+
+      expect(result).toBeNull();
+    });
+
+    it('returns null if initialization fails', async () => {
+      mockInstance.initialize.mockRejectedValue(new Error('Init failed'));
+
+      const result = await msalAuth.getSignedInAccount();
+
+      expect(result).toBeNull();
+    });
+
+    it('handles account with missing name', async () => {
+      const mockAccount = {
+        name: null,
+        username: 'test@example.com',
+        homeAccountId: 'home-id',
+        environment: 'login.microsoftonline.com',
+        tenantId: 'tenant-id',
+        localAccountId: 'local-id',
+      };
+
+      mockInstance.getActiveAccount.mockReturnValue(mockAccount as any);
+
+      const result = await msalAuth.getSignedInAccount();
+
+      expect(result).toEqual({
+        name: 'Unknown',
+        username: 'test@example.com',
+      });
+    });
+  });
+});

--- a/src/lib/msalAuth.ts
+++ b/src/lib/msalAuth.ts
@@ -1,0 +1,298 @@
+/**
+ * MSAL authentication for Microsoft Fabric REST APIs.
+ *
+ * Supports popup login with redirect-based fallback.
+ * Override the default app registration with VITE_FABRIC_CLIENT_ID env var.
+ */
+
+import {
+  PublicClientApplication,
+  type Configuration,
+  type AuthenticationResult,
+  InteractionRequiredAuthError,
+  BrowserAuthError,
+} from '@azure/msal-browser';
+
+// Client ID is supplied by the user via VITE_FABRIC_CLIENT_ID. There is no
+// built-in default — callers should fall back to the existing access-token
+// paste flow when this is empty (see isMsalConfigured()).
+const CLIENT_ID = (import.meta.env.VITE_FABRIC_CLIENT_ID ?? '').trim();
+
+const FABRIC_SCOPES = [
+  'https://api.fabric.microsoft.com/Workspace.ReadWrite.All',
+  'https://api.fabric.microsoft.com/Item.ReadWrite.All',
+];
+
+const ONELAKE_SCOPES = [
+  'https://storage.azure.com/user_impersonation',
+];
+
+const DEPLOY_PENDING_KEY = 'fabric_deploy_pending';
+const DEPLOY_HASH_KEY = 'fabric_deploy_hash';
+
+let initPromise: Promise<PublicClientApplication> | null = null;
+let redirectAuthResult: FabricAuthResult | null = null;
+
+function getMsalConfig(): Configuration {
+  return {
+    auth: {
+      clientId: CLIENT_ID,
+      authority: 'https://login.microsoftonline.com/organizations',
+      redirectUri: window.location.origin,
+    },
+    cache: {
+      cacheLocation: 'sessionStorage',
+    },
+  };
+}
+
+/**
+ * Initialize MSAL once. Processes any pending redirect response on first call.
+ */
+function getInstance(): Promise<PublicClientApplication> {
+  if (!initPromise) {
+    initPromise = (async () => {
+      const instance = new PublicClientApplication(getMsalConfig());
+      await instance.initialize();
+
+      // Process redirect response (only fires once after redirect-based login)
+      try {
+        const response = await instance.handleRedirectPromise();
+        if (response?.account) {
+          instance.setActiveAccount(response.account);
+          redirectAuthResult = {
+            accessToken: response.accessToken,
+            account: {
+              name: response.account.name ?? 'Unknown',
+              username: response.account.username ?? '',
+            },
+            expiresOn: response.expiresOn,
+          };
+        }
+      } catch {
+        // Redirect response unavailable or failed — that's fine
+      }
+
+      return instance;
+    })();
+  }
+  return initPromise;
+}
+
+export interface FabricAuthResult {
+  accessToken: string;
+  account: {
+    name: string;
+    username: string;
+  };
+  expiresOn: Date | null;
+}
+
+/**
+ * Returns true when a custom Fabric client ID has been configured.
+ * When false, callers should hide the popup-login flow and fall back
+ * to the existing access-token paste path.
+ */
+export function isMsalConfigured(): boolean {
+  return CLIENT_ID.length > 0;
+}
+
+/**
+ * Returns true if running on localhost without an MSAL client ID configured.
+ * In that case popup/redirect auth is disabled and the user must paste a token.
+ */
+export function isLocalhostWithDefaultClient(): boolean {
+  return !isMsalConfigured() && window.location.hostname === 'localhost';
+}
+
+/**
+ * Check if a redirect auth completed (call after MSAL init on page load).
+ */
+export async function consumeRedirectResult(): Promise<FabricAuthResult | null> {
+  await getInstance();
+  const result = redirectAuthResult;
+  redirectAuthResult = null;
+  return result;
+}
+
+/**
+ * Check if there's a pending deploy intent (set before redirect login).
+ */
+export function hasPendingDeployIntent(): boolean {
+  return sessionStorage.getItem(DEPLOY_PENDING_KEY) === 'true';
+}
+
+/**
+ * Clear the pending deploy intent.
+ */
+export function clearDeployIntent(): void {
+  const savedHash = sessionStorage.getItem(DEPLOY_HASH_KEY);
+  sessionStorage.removeItem(DEPLOY_PENDING_KEY);
+  sessionStorage.removeItem(DEPLOY_HASH_KEY);
+  // Restore the hash route if it was saved before redirect
+  if (savedHash && window.location.hash !== savedHash) {
+    window.location.hash = savedHash;
+  }
+}
+
+/**
+ * Acquire a Fabric API token.
+ * Tries silent first, falls back to redirect (not popup).
+ */
+export const MSAL_NOT_CONFIGURED_MESSAGE =
+  'MSAL sign-in is not configured. Set VITE_FABRIC_CLIENT_ID in your .env (see DEPLOYMENT.md) or paste an access token to deploy.';
+
+export async function acquireFabricToken(): Promise<FabricAuthResult> {
+  if (!isMsalConfigured()) {
+    throw new Error(MSAL_NOT_CONFIGURED_MESSAGE);
+  }
+  const instance = await getInstance();
+  const active = instance.getActiveAccount();
+  const accounts = active ? [active] : instance.getAllAccounts();
+
+  let result: AuthenticationResult;
+
+  if (accounts.length > 0) {
+    try {
+      result = await instance.acquireTokenSilent({
+        scopes: FABRIC_SCOPES,
+        account: accounts[0],
+      });
+    } catch (err) {
+      if (err instanceof InteractionRequiredAuthError) {
+        // Redirect instead of popup — popup is unreliable
+        await signInWithRedirect();
+        throw new Error('Redirecting for re-authentication…');
+      } else {
+        throw err;
+      }
+    }
+  } else {
+    await signInWithRedirect();
+    throw new Error('No signed-in account. Redirecting to sign in…');
+  }
+
+  if (result.account) {
+    instance.setActiveAccount(result.account);
+  }
+
+  return {
+    accessToken: result.accessToken,
+    account: {
+      name: result.account?.name ?? 'Unknown',
+      username: result.account?.username ?? '',
+    },
+    expiresOn: result.expiresOn,
+  };
+}
+
+/**
+ * Acquire a OneLake DFS token (storage.azure.com audience).
+ * Needed for uploading files to Lakehouse Files/ area.
+ */
+export async function acquireOneLakeToken(): Promise<FabricAuthResult> {
+  if (!isMsalConfigured()) {
+    throw new Error(MSAL_NOT_CONFIGURED_MESSAGE);
+  }
+  const instance = await getInstance();
+  const active = instance.getActiveAccount();
+  const accounts = active ? [active] : instance.getAllAccounts();
+
+  let result: AuthenticationResult;
+
+  if (accounts.length > 0) {
+    try {
+      result = await instance.acquireTokenSilent({
+        scopes: ONELAKE_SCOPES,
+        account: accounts[0],
+      });
+    } catch (err) {
+      if (err instanceof InteractionRequiredAuthError) {
+        // Don't redirect mid-push — that would lose all push state.
+        // The user needs to sign out and sign back in to consent to OneLake scope.
+        throw new Error(
+          'OneLake consent required. Please sign out and sign back in to grant storage permissions, then retry.',
+        );
+      }
+      throw err;
+    }
+  } else {
+    throw new Error('No signed-in account. Please sign in first.');
+  }
+
+  return {
+    accessToken: result.accessToken,
+    account: {
+      name: result.account?.name ?? 'Unknown',
+      username: result.account?.username ?? '',
+    },
+    expiresOn: result.expiresOn,
+  };
+}
+
+/**
+ * Initiate redirect-based login (navigates away from page).
+ * Saves deploy intent + current hash route to sessionStorage.
+ */
+export async function signInWithRedirect(): Promise<void> {
+  if (!isMsalConfigured()) {
+    throw new Error(MSAL_NOT_CONFIGURED_MESSAGE);
+  }
+  sessionStorage.setItem(DEPLOY_PENDING_KEY, 'true');
+  sessionStorage.setItem(DEPLOY_HASH_KEY, window.location.hash);
+  const instance = await getInstance();
+  await instance.acquireTokenRedirect({
+    scopes: FABRIC_SCOPES,
+    // Pre-consent OneLake scope so later acquireTokenSilent works without interaction
+    extraScopesToConsent: ONELAKE_SCOPES,
+  });
+}
+
+/**
+ * Returns true if the given error is a popup timeout or blocked popup.
+ */
+export function isPopupError(err: unknown): boolean {
+  if (err instanceof BrowserAuthError) {
+    const code = (err as { errorCode?: string }).errorCode ?? '';
+    return code === 'popup_window_error' || code === 'monitor_window_timeout'
+      || code === 'empty_window_error' || code === 'user_cancelled';
+  }
+  if (err instanceof Error) {
+    const msg = err.message.toLowerCase();
+    return msg.includes('timed_out') || msg.includes('popup') || msg.includes('blocked');
+  }
+  return false;
+}
+
+/**
+ * Sign out and clear cached tokens.
+ */
+export async function signOut(): Promise<void> {
+  const instance = await getInstance();
+  const active = instance.getActiveAccount();
+  const account = active ?? instance.getAllAccounts()[0];
+  if (account) {
+    await instance.logoutPopup({ account });
+  }
+  initPromise = null;
+}
+
+/**
+ * Check if user is already signed in (has cached account).
+ */
+export async function getSignedInAccount(): Promise<FabricAuthResult['account'] | null> {
+  try {
+    const instance = await getInstance();
+    const active = instance.getActiveAccount();
+    const account = active ?? instance.getAllAccounts()[0];
+    if (account) {
+      return {
+        name: account.name ?? 'Unknown',
+        username: account.username ?? '',
+      };
+    }
+  } catch {
+    // MSAL not configured — that's fine
+  }
+  return null;
+}

--- a/src/lib/sampleDataGenerator.ts
+++ b/src/lib/sampleDataGenerator.ts
@@ -1,0 +1,136 @@
+/**
+ * Sample data generator for ontology deployment to Fabric.
+ * Produces realistic EntityInstance[] for a small set of well-known
+ * ontologies (Finance) and a generic fallback for any other ontology.
+ *
+ * Domain-specific samples (e.g. Wind Power) have intentionally been
+ * omitted from this file; users can add their own generators or pass
+ * EntityInstance[] directly to the deploy pipeline.
+ */
+
+import type { Ontology, EntityInstance } from '../data/ontology';
+
+// ─── Finance Sample Data ───────────────────────────────────────────────────
+
+function generateFinanceCustomers(): EntityInstance[] {
+  const names = ['Alice Johnson', 'Bob Smith', 'Carol Williams', 'David Brown', 'Eva Martinez',
+    'Frank Lee', 'Grace Kim', 'Henry Davis', 'Iris Patel', 'Jack Wilson'];
+  return names.map((name, i) => ({
+    id: `cust-${String(i + 1).padStart(3, '0')}`,
+    entityTypeId: 'Customer',
+    values: {
+      customerId: `C-${String(1000 + i)}`,
+      name,
+      email: `${name.toLowerCase().replace(' ', '.')}@example.com`,
+      segment: i < 3 ? 'premium' : i < 7 ? 'standard' : 'basic',
+      joinDate: `202${Math.floor(i / 3)}-${String((i % 12) + 1).padStart(2, '0')}-15`,
+    },
+  }));
+}
+
+function generateFinanceAccounts(): EntityInstance[] {
+  const types = ['checking', 'savings', 'checking', 'savings', 'investment'];
+  return types.map((type, i) => ({
+    id: `acct-${String(i + 1).padStart(3, '0')}`,
+    entityTypeId: 'Account',
+    values: {
+      accountId: `A-${String(2000 + i)}`,
+      type,
+      balance: Math.round((5000 + Math.random() * 95000) * 100) / 100,
+      currency: 'USD',
+      openDate: `2022-${String((i * 2 % 12) + 1).padStart(2, '0')}-01`,
+      isActive: true,
+    },
+  }));
+}
+
+function generateFinanceTransactions(): EntityInstance[] {
+  const categories = ['deposit', 'withdrawal', 'transfer', 'payment', 'fee'];
+  const transactions: EntityInstance[] = [];
+  for (let i = 0; i < 30; i++) {
+    const cat = categories[i % categories.length];
+    transactions.push({
+      id: `txn-${String(i + 1).padStart(3, '0')}`,
+      entityTypeId: 'Transaction',
+      values: {
+        transactionId: `TXN-${String(3000 + i)}`,
+        amount: Math.round((cat === 'fee' ? 5 + Math.random() * 25 : 50 + Math.random() * 5000) * 100) / 100,
+        type: cat,
+        timestamp: `2025-${String((i % 12) + 1).padStart(2, '0')}-${String((i % 28) + 1).padStart(2, '0')}T${String(9 + (i % 9))}:${String(i % 60).padStart(2, '0')}:00Z`,
+        description: `${cat.charAt(0).toUpperCase() + cat.slice(1)} - ref ${i + 1}`,
+        status: i < 28 ? 'completed' : 'pending',
+      },
+    });
+  }
+  return transactions;
+}
+
+// ─── Public API ────────────────────────────────────────────────────────────
+
+export interface GeneratedData {
+  ontologyName: string;
+  tables: Map<string, EntityInstance[]>;
+}
+
+/**
+ * Generate sample data for an ontology based on its name/slug.
+ * - Finance / banking ontologies get a curated dataset.
+ * - All other ontologies get a generic per-entity dataset based on property types.
+ */
+export function generateSampleData(ontology: Ontology): GeneratedData {
+  const tables = new Map<string, EntityInstance[]>();
+  const name = ontology.name.toLowerCase();
+
+  if (name.includes('finance') || name.includes('banking')) {
+    tables.set('Customer', generateFinanceCustomers());
+    tables.set('Account', generateFinanceAccounts());
+    tables.set('Transaction', generateFinanceTransactions());
+  } else {
+    for (const entity of ontology.entityTypes) {
+      const instances: EntityInstance[] = [];
+      for (let i = 0; i < 5; i++) {
+        const values: Record<string, unknown> = {};
+        for (const prop of entity.properties) {
+          values[prop.name] = generateDefaultValue(prop.type, prop.name, i);
+        }
+        instances.push({ id: `${entity.id}-${i + 1}`, entityTypeId: entity.id, values });
+      }
+      tables.set(entity.name, instances);
+    }
+  }
+
+  return { ontologyName: ontology.name, tables };
+}
+
+function generateDefaultValue(type: string, name: string, index: number): unknown {
+  switch (type) {
+    case 'string': return `${name}_${index + 1}`;
+    case 'integer': return index * 10 + 1;
+    case 'decimal':
+    case 'double': return Math.round((index * 10.5 + 1) * 100) / 100;
+    case 'boolean': return index % 2 === 0;
+    case 'date': return `2025-${String((index % 12) + 1).padStart(2, '0')}-01`;
+    case 'datetime': return `2025-${String((index % 12) + 1).padStart(2, '0')}-01T00:00:00Z`;
+    default: return `${name}_${index + 1}`;
+  }
+}
+
+/**
+ * Convert EntityInstance[] to CSV string for Lakehouse upload.
+ */
+export function instancesToCSV(instances: EntityInstance[]): string {
+  if (instances.length === 0) return '';
+
+  const columns = Object.keys(instances[0].values);
+  const header = columns.join(',');
+  const rows = instances.map(inst =>
+    columns.map(col => {
+      const val = inst.values[col];
+      if (val === null || val === undefined) return '';
+      if (typeof val === 'string') return `"${val.replace(/"/g, '""')}"`;
+      return String(val);
+    }).join(','),
+  );
+
+  return [header, ...rows].join('\n');
+}


### PR DESCRIPTION
…and MSAL auth

Adds an end-to-end deploy wizard that pushes a complete Fabric solution from the Ontology Playground UI to a user-selected workspace.

What's new:

- Workspace picker (list/select existing workspaces or create a new one)

- Multi-step wizard: auth -> workspace -> ontologies -> configure -> deploy -> done

- Lakehouse client with CSV upload to OneLake Files API

- Power BI Semantic Model client (DirectLake)

- Fabric GraphQL API client

- Fabric Data Agent client

- Deploy pipeline orchestrator with per-step progress callbacks

- Generic sample-data generator (Finance + fallback)

Auth (hybrid):

- MSAL interactive login when VITE_FABRIC_CLIENT_ID env var is set

- Token-paste fallback when no client ID is configured (no app ID baked in)

- See .env.example and DEPLOYMENT.md for setup

Tests: 88 new tests across 6 fabric modules; full suite (384 tests) passes.