### PR TITLE
feat: Graph Explorer UX — Insights panel, Path Finder, Focus mode, PNG export, edge label & inspector polish

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -21,7 +21,9 @@ import {
   CommandPalette,
   GuidedTour,
   isTourDismissed,
-  AppFooter
+  AppFooter,
+  OntologyStatsPanel,
+  PathFinderPanel
 } from './components';
 import type { CommandItem } from './components';
 import { useAppStore } from './store/appStore';
@@ -195,6 +197,8 @@ function App() {
       <QuestPanel />
       <OntologyGraph />
       <div className="right-sidebar">
+        <OntologyStatsPanel />
+        <PathFinderPanel />
         <SearchFilter />
         <InspectorPanel />
         <QueryPlayground />

--- a/src/components/InspectorPanel.tsx
+++ b/src/components/InspectorPanel.tsx
@@ -152,23 +152,23 @@ export function InspectorPanel() {
               const otherEntity = currentOntology.entityTypes.find(e => e.id === otherEntityId);
               
               return (
-                <div key={rel.id} className="property-item">
-                  <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+                <div key={rel.id} className="property-item rel-item">
+                  <div className="rel-item-row">
                     {isOutgoing ? (
                       <>
                         <span className="property-name">{rel.name}</span>
-                        <ArrowRight size={14} style={{ color: 'var(--ms-blue)' }} />
-                        <span>{otherEntity?.icon} {otherEntity?.name}</span>
+                        <ArrowRight size={12} className="rel-item-arrow" />
+                        <span className="rel-item-entity">{otherEntity?.icon} {otherEntity?.name}</span>
                       </>
                     ) : (
                       <>
-                        <span>{otherEntity?.icon} {otherEntity?.name}</span>
-                        <ArrowRight size={14} style={{ color: 'var(--ms-blue)' }} />
+                        <span className="rel-item-entity">{otherEntity?.icon} {otherEntity?.name}</span>
+                        <ArrowRight size={12} className="rel-item-arrow" />
                         <span className="property-name">{rel.name}</span>
                       </>
                     )}
                   </div>
-                  <span className="property-type">{rel.cardinality}</span>
+                  <div className="rel-item-cardinality">{rel.cardinality}</div>
                 </div>
               );
             })}

--- a/src/components/OntologyGraph.tsx
+++ b/src/components/OntologyGraph.tsx
@@ -1,9 +1,9 @@
-import { useEffect, useRef, useCallback, useMemo } from 'react';
+import { useEffect, useRef, useCallback, useMemo, useState } from 'react';
 import cytoscape from 'cytoscape';
 import fcose from 'cytoscape-fcose';
 import type { Core, EventObject, LayoutOptions } from 'cytoscape';
 import { useAppStore } from '../store/appStore';
-import { ZoomIn, ZoomOut, Maximize2, RotateCcw } from 'lucide-react';
+import { ZoomIn, ZoomOut, Maximize2, RotateCcw, Download, Crosshair } from 'lucide-react';
 
 // Register fcose layout
 cytoscape.use(fcose);
@@ -12,6 +12,8 @@ export function OntologyGraph() {
   const cyRef = useRef<Core | null>(null);
   const containerRef = useRef<HTMLDivElement>(null);
   const mountedRef = useRef(true);
+  const [focusNodeId, setFocusNodeId] = useState<string | null>(null);
+  const focusNodeIdRef = useRef<string | null>(null);
   
   // Helper to safely get cytoscape instance - returns null if destroyed
   const getCy = useCallback(() => {
@@ -156,11 +158,17 @@ export function OntologyGraph() {
           selector: 'edge',
           style: {
             'label': 'data(label)',
-            'font-size': '12px',
+            'font-size': '11px',
             'font-family': 'Segoe UI, sans-serif',
             'color': initialThemeColors.current.edgeText,
             'text-rotation': 'autorotate',
             'text-margin-y': -10,
+            'text-wrap': 'ellipsis',
+            'text-max-width': '120px',
+            'text-background-color': initialThemeColors.current.nodeText === '#B3B3B3' ? '#1a1a2e' : '#f5f5f5',
+            'text-background-opacity': 0.75,
+            'text-background-padding': '2px',
+            'text-background-shape': 'roundrectangle',
             'width': 3,
             'line-color': initialThemeColors.current.edgeColor,
             'target-arrow-color': initialThemeColors.current.edgeColor,
@@ -258,8 +266,34 @@ export function OntologyGraph() {
 
     cy.on('tap', (evt: EventObject) => {
       if (evt.target === cy) {
+        // Exit focus mode BEFORE clearing selection so the selection effect
+        // doesn't see a stale focusNodeIdRef and skip its dimmed cleanup
+        if (focusNodeIdRef.current !== null) {
+          focusNodeIdRef.current = null;
+          setFocusNodeId(null);
+          getCy()?.elements().removeClass('dimmed focus-hidden');
+        }
         selectEntity(null);
         selectRelationship(null);
+      }
+    });
+
+    cy.on('dbltap', 'node', (evt: EventObject) => {
+      const nodeId = evt.target.id();
+      const alreadyFocused = focusNodeIdRef.current === nodeId;
+
+      if (alreadyFocused) {
+        // Toggle off
+        focusNodeIdRef.current = null;
+        setFocusNodeId(null);
+        cy.elements().removeClass('dimmed focus-hidden');
+      } else {
+        focusNodeIdRef.current = nodeId;
+        setFocusNodeId(nodeId);
+        const node = cy.getElementById(nodeId);
+        const neighbourhood = node.closedNeighborhood();
+        cy.elements().addClass('dimmed');
+        neighbourhood.removeClass('dimmed');
       }
     });
 
@@ -289,31 +323,60 @@ export function OntologyGraph() {
     };
   }, [buildElements, selectEntity, selectRelationship]);
 
+  // Keep focusNodeIdRef in sync with state
+  useEffect(() => {
+    focusNodeIdRef.current = focusNodeId;
+  }, [focusNodeId]);
+
+  // Re-apply focus neighbourhood when focusNodeId changes
+  useEffect(() => {
+    const cy = getCy();
+    if (!cy) return;
+    if (focusNodeId === null) {
+      cy.elements().removeClass('dimmed');
+    } else {
+      const node = cy.getElementById(focusNodeId);
+      if (node.length) {
+        cy.elements().addClass('dimmed');
+        node.closedNeighborhood().removeClass('dimmed');
+      }
+    }
+  }, [focusNodeId, getCy]);
+
   // Update graph colors when theme changes (without recreating graph)
   useEffect(() => {
     const cy = getCy();
     if (!cy) return;
 
     try {
-      cy.style()
-        .selector('node')
-        .style({ 'color': themeColors.nodeText })
-        .selector('edge')
-        .style({
-          'color': themeColors.edgeText,
-          'line-color': themeColors.edgeColor,
-          'target-arrow-color': themeColors.edgeColor
-        })
-        .update();
+      // Apply text-color update to ALL edges/nodes (text colors don't affect highlight line-color)
+      cy.$('node').style({ 'color': themeColors.nodeText });
+      cy.$('edge').style({ 'color': themeColors.edgeText, 'text-background-color': darkMode ? '#1a1a2e' : '#f5f5f5' });
+      // Line/arrow colors: only update non-highlighted edges so path-finder highlights survive
+      cy.$('edge:not(.highlighted)').style({
+        'line-color': themeColors.edgeColor,
+        'target-arrow-color': themeColors.edgeColor,
+      });
     } catch {
       // Graph may have been destroyed
     }
-  }, [themeColors, getCy]);
+  }, [themeColors, darkMode, getCy]);
 
   // Handle selection changes
   useEffect(() => {
     const cy = getCy();
     if (!cy) return;
+
+    // If focus mode is active, let the focus effect manage dimming
+    if (focusNodeIdRef.current !== null) {
+      // Just update selection highlight without touching dimmed
+      try {
+        cy.elements().unselect();
+        if (selectedEntityId) cy.getElementById(selectedEntityId).select();
+        if (selectedRelationshipId) cy.getElementById(selectedRelationshipId).select();
+      } catch { /* ignore */ }
+      return;
+    }
 
     try {
       cy.elements().removeClass('highlighted dimmed');
@@ -354,6 +417,11 @@ export function OntologyGraph() {
     if (!cy) return;
 
     try {
+      // Clear previous highlights and restore theme line colors on previously-highlighted edges
+      cy.$('edge.highlighted').style({
+        'line-color': themeColors.edgeColor,
+        'target-arrow-color': themeColors.edgeColor,
+      });
       cy.elements().removeClass('highlighted');
 
       highlightedEntities.forEach(id => {
@@ -361,12 +429,15 @@ export function OntologyGraph() {
       });
 
       highlightedRelationships.forEach(id => {
-        cy.getElementById(id).addClass('highlighted');
+        const el = cy.getElementById(id);
+        el.addClass('highlighted');
+        // Force bypass so it overrides any theme update residue
+        el.style({ 'line-color': '#FFB900', 'target-arrow-color': '#FFB900' });
       });
     } catch {
       // Graph may have been destroyed
     }
-  }, [highlightedEntities, highlightedRelationships, getCy]);
+  }, [highlightedEntities, highlightedRelationships, themeColors, getCy]);
 
   // Graph controls
   const handleZoomIn = () => {
@@ -420,9 +491,40 @@ export function OntologyGraph() {
     }
   };
 
+  const handleDownload = () => {
+    const cy = getCy();
+    if (!cy) return;
+    try {
+      const bg = darkMode ? '#1E1E1E' : '#F5F5F5';
+      const pngData = cy.png({ scale: 2, full: true, bg });
+      const link = document.createElement('a');
+      link.href = pngData;
+      const safeName = (currentOntology.name || 'ontology').toLowerCase().replace(/\s+/g, '-');
+      link.download = `${safeName}-graph.png`;
+      link.click();
+    } catch { /* ignore */ }
+  };
+
   return (
     <div className="graph-container">
       <div ref={containerRef} className="graph-canvas" />
+
+      {focusNodeId && (
+        <div className="graph-focus-badge">
+          <Crosshair size={13} />
+          <span>Focus mode</span>
+          <button
+            className="graph-focus-exit"
+            onClick={() => {
+              setFocusNodeId(null);
+              const cy = getCy();
+              if (cy) cy.elements().removeClass('dimmed');
+            }}
+          >
+            Click background or ✕ to exit
+          </button>
+        </div>
+      )}
       
       <div className="graph-controls">
         <button className="graph-control-btn" onClick={handleZoomIn} title="Zoom In">
@@ -436,6 +538,9 @@ export function OntologyGraph() {
         </button>
         <button className="graph-control-btn" onClick={handleReset} title="Reset Layout">
           <RotateCcw size={18} />
+        </button>
+        <button className="graph-control-btn" onClick={handleDownload} title="Download Graph as PNG">
+          <Download size={18} />
         </button>
       </div>
 

--- a/src/components/OntologyStatsPanel.tsx
+++ b/src/components/OntologyStatsPanel.tsx
@@ -1,0 +1,64 @@
+import { useState, useMemo } from 'react';
+import { BarChart2, ChevronDown, ChevronUp, Network, Link2, Layers } from 'lucide-react';
+import { useAppStore } from '../store/appStore';
+
+export function OntologyStatsPanel() {
+  const { currentOntology } = useAppStore();
+  const [expanded, setExpanded] = useState(true);
+
+  const stats = useMemo(() => {
+    const { entityTypes, relationships } = currentOntology;
+
+    const entityCount = entityTypes.length;
+    const relationshipCount = relationships.length;
+    const totalProperties = entityTypes.reduce((sum, e) => sum + e.properties.length, 0);
+
+    return {
+      entityCount,
+      relationshipCount,
+      totalProperties,
+    };
+  }, [currentOntology]);
+
+  return (
+    <div className="stats-panel">
+      <button
+        className="stats-panel-header"
+        onClick={() => setExpanded(prev => !prev)}
+        aria-expanded={expanded}
+        aria-controls="stats-panel-body"
+      >
+        <span className="stats-panel-title">
+          <BarChart2 size={14} />
+          Ontology Insights
+        </span>
+        {expanded ? <ChevronUp size={14} /> : <ChevronDown size={14} />}
+      </button>
+
+      {expanded && (
+        <div id="stats-panel-body" className="stats-panel-body">
+          {/* Primary metrics row */}
+          <div className="stats-grid">
+            <div className="stat-card stat-card--blue">
+              <Layers size={16} className="stat-card-icon" />
+              <div className="stat-card-value">{stats.entityCount}</div>
+              <div className="stat-card-label">Entities</div>
+            </div>
+            <div className="stat-card stat-card--purple">
+              <Link2 size={16} className="stat-card-icon" />
+              <div className="stat-card-value">{stats.relationshipCount}</div>
+              <div className="stat-card-label">Relationships</div>
+            </div>
+            <div className="stat-card stat-card--green">
+              <Network size={16} className="stat-card-icon" />
+              <div className="stat-card-value">{stats.totalProperties}</div>
+              <div className="stat-card-label">Properties</div>
+            </div>
+          </div>
+
+
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/PathFinderPanel.tsx
+++ b/src/components/PathFinderPanel.tsx
@@ -1,0 +1,226 @@
+import { useState, useMemo, useCallback, useEffect } from 'react';
+import { GitFork, ChevronDown, ChevronUp, ArrowRight, Search, X } from 'lucide-react';
+import { useAppStore } from '../store/appStore';
+import type { Relationship } from '../data/ontology';
+
+interface PathStep {
+  entityId: string;
+  entityName: string;
+  entityIcon: string;
+  relationship?: {
+    id: string;
+    name: string;
+    cardinality: string;
+    forward: boolean; // true = from→to, false = to→from (traversed backwards)
+  };
+}
+
+type BFSNode = { entityId: string; via?: { rel: Relationship; forward: boolean } };
+
+/** BFS over the undirected relationship graph — returns the shortest hop path */
+function findShortestPath(
+  fromId: string,
+  toId: string,
+  relationships: Relationship[]
+): BFSNode[] | null {
+  if (fromId === toId) return null;
+
+  // Build adjacency: entityId → [{ neighbourId, rel }]
+  const adj: Record<string, { neighbourId: string; rel: Relationship; forward: boolean }[]> = {};
+  for (const rel of relationships) {
+    if (!adj[rel.from]) adj[rel.from] = [];
+    if (!adj[rel.to]) adj[rel.to] = [];
+    adj[rel.from].push({ neighbourId: rel.to, rel, forward: true });
+    adj[rel.to].push({ neighbourId: rel.from, rel, forward: false });
+  }
+
+  // BFS
+  const visited = new Set<string>([fromId]);
+  const queue: { entityId: string; path: BFSNode[] }[] = [
+    { entityId: fromId, path: [{ entityId: fromId }] }
+  ];
+
+  while (queue.length > 0) {
+    const { entityId, path } = queue.shift()!;
+    for (const { neighbourId, rel, forward } of (adj[entityId] ?? [])) {
+      if (visited.has(neighbourId)) continue;
+      visited.add(neighbourId);
+      const newPath = [...path, { entityId: neighbourId, via: { rel, forward } }];
+      if (neighbourId === toId) {
+        return newPath;
+      }
+      queue.push({ entityId: neighbourId, path: newPath });
+    }
+  }
+  return null; // No path
+}
+
+export function PathFinderPanel() {
+  const { currentOntology, setHighlights, clearHighlights } = useAppStore();
+  const [expanded, setExpanded] = useState(false);
+  const [fromId, setFromId] = useState('');
+  const [toId, setToId] = useState('');
+  const [searched, setSearched] = useState(false);
+
+  const entities = currentOntology.entityTypes;
+  const relationships = currentOntology.relationships;
+
+  const path = useMemo<BFSNode[] | null>(() => {
+    if (!searched || !fromId || !toId) return null;
+    return findShortestPath(fromId, toId, relationships);
+  }, [searched, fromId, toId, relationships]);
+
+  // Build display steps from raw BFS path
+  const displaySteps = useMemo<PathStep[]>(() => {
+    if (!path) return [];
+    return path.map((node) => {
+      const entity = entities.find(e => e.id === node.entityId);
+      return {
+        entityId: node.entityId,
+        entityName: entity?.name ?? node.entityId,
+        entityIcon: entity?.icon ?? '📦',
+        relationship: node.via
+          ? {
+              id: node.via.rel.id,
+              name: node.via.rel.name,
+              cardinality: node.via.rel.cardinality,
+              forward: node.via.forward,
+            }
+          : undefined,
+      };
+    });
+  }, [path, entities]);
+
+  const handleFind = useCallback(() => {
+    setSearched(true);
+    if (!fromId || !toId) return;
+    // Highlights will be applied via the useMemo path result below
+  }, [fromId, toId]);
+
+  // Apply highlights whenever path changes
+  useEffect(() => {
+    if (!searched || !path) {
+      if (searched) clearHighlights();
+      return;
+    }
+    const entityIds = path.map(n => n.entityId);
+    const relIds = path.filter(n => n.via).map(n => n.via!.rel.id);
+    setHighlights(entityIds, relIds);
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [path, searched]);
+
+  const handleClear = useCallback(() => {
+    setFromId('');
+    setToId('');
+    setSearched(false);
+    clearHighlights();
+  }, [clearHighlights]);
+
+  const noPath = searched && fromId && toId && !path;
+  const sameEntity = fromId && toId && fromId === toId;
+
+  return (
+    <div className="pathfinder-panel">
+      <button
+        className="pathfinder-header"
+        onClick={() => setExpanded(prev => !prev)}
+        aria-expanded={expanded}
+      >
+        <span className="pathfinder-title">
+          <GitFork size={14} />
+          Path Finder
+        </span>
+        {expanded ? <ChevronUp size={14} /> : <ChevronDown size={14} />}
+      </button>
+
+      {expanded && (
+        <div className="pathfinder-body">
+          <div className="pathfinder-selects">
+            <div className="pathfinder-select-group">
+              <label className="pathfinder-label">From</label>
+              <select
+                className="pathfinder-select"
+                value={fromId}
+                onChange={e => { setFromId(e.target.value); setSearched(false); clearHighlights(); }}
+              >
+                <option value="">Select entity…</option>
+                {entities.map(e => (
+                  <option key={e.id} value={e.id}>{e.icon} {e.name}</option>
+                ))}
+              </select>
+            </div>
+
+            <ArrowRight size={16} className="pathfinder-arrow-icon" />
+
+            <div className="pathfinder-select-group">
+              <label className="pathfinder-label">To</label>
+              <select
+                className="pathfinder-select"
+                value={toId}
+                onChange={e => { setToId(e.target.value); setSearched(false); clearHighlights(); }}
+              >
+                <option value="">Select entity…</option>
+                {entities.map(e => (
+                  <option key={e.id} value={e.id}>{e.icon} {e.name}</option>
+                ))}
+              </select>
+            </div>
+          </div>
+
+          <div className="pathfinder-actions">
+            <button
+              className="pathfinder-btn-find"
+              onClick={handleFind}
+              disabled={!fromId || !toId || !!sameEntity}
+            >
+              <Search size={13} />
+              Find Path
+            </button>
+            {searched && (
+              <button className="pathfinder-btn-clear" onClick={handleClear}>
+                <X size={13} />
+                Clear
+              </button>
+            )}
+          </div>
+
+          {sameEntity && (
+            <div className="pathfinder-message pathfinder-message--warn">
+              Select two different entities.
+            </div>
+          )}
+
+          {noPath && (
+            <div className="pathfinder-message pathfinder-message--warn">
+              No connection found between these entities.
+            </div>
+          )}
+
+          {displaySteps.length > 0 && (
+            <div className="pathfinder-result">
+              <div className="pathfinder-result-label">
+                Shortest path — {displaySteps.length - 1} hop{displaySteps.length - 1 !== 1 ? 's' : ''}
+              </div>
+              <div className="pathfinder-chain">
+                {displaySteps.map((step, i) => (
+                  <div key={step.entityId} className="pathfinder-chain-item">
+                    {step.relationship && (
+                      <div className="pathfinder-chain-rel">
+                        <div className="pathfinder-chain-rel-arrow" />
+                        <span className="pathfinder-chain-rel-name">{step.relationship.name}</span>
+                      </div>
+                    )}
+                    <div className={`pathfinder-chain-node ${i === 0 ? 'pathfinder-chain-node--start' : i === displaySteps.length - 1 ? 'pathfinder-chain-node--end' : ''}`}>
+                      <span className="pathfinder-chain-icon">{step.entityIcon}</span>
+                      <span className="pathfinder-chain-name">{step.entityName}</span>
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -21,3 +21,5 @@ export { Toast } from './Toast';
 export { CommandPalette } from './CommandPalette';
 export type { CommandItem } from './CommandPalette';
 export { GuidedTour, isTourDismissed } from './GuidedTour';
+export { OntologyStatsPanel } from './OntologyStatsPanel';
+export { PathFinderPanel } from './PathFinderPanel';

--- a/src/store/appStore.ts
+++ b/src/store/appStore.ts
@@ -53,6 +53,7 @@ interface AppState {
   selectRelationship: (id: string | null) => void;
   setHighlightedEntities: (ids: string[]) => void;
   setHighlightedRelationships: (ids: string[]) => void;
+  setHighlights: (entityIds: string[], relIds: string[]) => void;
   toggleDataBindings: () => void;
   toggleDarkMode: () => void;
   
@@ -143,6 +144,7 @@ export const useAppStore = create<AppState>((set, get) => ({
   
   setHighlightedEntities: (ids) => set({ highlightedEntities: ids }),
   setHighlightedRelationships: (ids) => set({ highlightedRelationships: ids }),
+  setHighlights: (entityIds, relIds) => set({ highlightedEntities: entityIds, highlightedRelationships: relIds }),
   
   toggleDataBindings: () => set((state) => ({ showDataBindings: !state.showDataBindings })),
   toggleDarkMode: () => set((state) => {

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -547,6 +547,42 @@ body {
   border-color: var(--ms-blue);
 }
 
+/* Focus mode badge */
+.graph-focus-badge {
+  position: absolute;
+  top: 16px;
+  left: 50%;
+  transform: translateX(-50%);
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 12px;
+  background: rgba(0, 120, 212, 0.92);
+  color: white;
+  border-radius: 20px;
+  font-size: 12px;
+  font-weight: 600;
+  pointer-events: none;
+  backdrop-filter: blur(4px);
+  box-shadow: 0 2px 8px rgba(0,0,0,0.3);
+}
+
+.graph-focus-exit {
+  background: rgba(255,255,255,0.2);
+  border: none;
+  color: white;
+  font-size: 11px;
+  font-family: inherit;
+  padding: 2px 8px;
+  border-radius: 10px;
+  cursor: pointer;
+  pointer-events: all;
+}
+
+.graph-focus-exit:hover {
+  background: rgba(255,255,255,0.35);
+}
+
 .graph-legend {
   position: absolute;
   bottom: 24px;
@@ -585,7 +621,7 @@ body {
 .right-sidebar {
   display: flex;
   flex-direction: column;
-  overflow: hidden;
+  overflow-y: auto;
   background: var(--bg-secondary);
   border-left: 1px solid var(--border-color);
 }
@@ -599,12 +635,10 @@ body {
 
 /* Right Panel - Inspector */
 .inspector-panel {
-  flex: 1;
-  min-height: 0;
+  flex-shrink: 0;
   background: var(--bg-secondary);
   display: flex;
   flex-direction: column;
-  overflow: hidden;
   color: var(--text-primary);
 }
 
@@ -637,8 +671,6 @@ body {
 }
 
 .inspector-content {
-  flex: 1;
-  overflow-y: auto;
   padding: 20px;
 }
 
@@ -703,6 +735,39 @@ body {
   border-radius: var(--radius-md);
   border: 1px solid var(--border-subtle);
   color: var(--text-primary);
+}
+
+/* Two-line relationship layout */
+.rel-item {
+  flex-direction: column;
+  gap: 4px;
+}
+
+.rel-item-row {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex-wrap: nowrap;
+  overflow: hidden;
+}
+
+.rel-item-arrow {
+  color: var(--ms-blue);
+  flex-shrink: 0;
+}
+
+.rel-item-entity {
+  font-size: 13px;
+  color: var(--text-primary);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.rel-item-cardinality {
+  font-size: 11px;
+  color: var(--ms-blue);
+  font-family: var(--font-mono);
 }
 
 .property-name {
@@ -3524,6 +3589,256 @@ body {
   flex-shrink: 0;
 }
 
+/* ── Ontology Stats Panel ─────────────────────────────────────── */
+.stats-panel {
+  flex-shrink: 0;
+  border-bottom: 1px solid var(--border-subtle);
+}
+
+.stats-panel-header {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 10px 16px;
+  background: transparent;
+  border: none;
+  color: var(--text-secondary);
+  cursor: pointer;
+  font-family: inherit;
+  transition: background var(--transition-fast);
+}
+
+.stats-panel-header:hover {
+  background: var(--bg-tertiary);
+}
+
+.stats-panel-title {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 12px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  color: var(--text-secondary);
+}
+
+.stats-panel-body {
+  padding: 12px 16px 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+/* Metric cards grid */
+.stats-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 8px;
+}
+
+.stat-card {
+  border-radius: var(--radius-md);
+  padding: 10px 8px 8px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 4px;
+  border: 1px solid transparent;
+}
+
+.stat-card--blue {
+  background: rgba(0, 120, 212, 0.12);
+  border-color: rgba(0, 120, 212, 0.25);
+}
+
+.stat-card--purple {
+  background: rgba(92, 45, 145, 0.12);
+  border-color: rgba(92, 45, 145, 0.25);
+}
+
+.stat-card--green {
+  background: rgba(16, 124, 16, 0.12);
+  border-color: rgba(16, 124, 16, 0.25);
+}
+
+.stat-card-icon {
+  opacity: 0.7;
+}
+
+.stat-card--blue .stat-card-icon { color: var(--ms-blue); }
+.stat-card--purple .stat-card-icon { color: #8a52d4; }
+.stat-card--green .stat-card-icon { color: var(--ms-green-light); }
+
+.stat-card-value {
+  font-size: 22px;
+  font-weight: 700;
+  line-height: 1;
+}
+
+.stat-card--blue .stat-card-value { color: var(--ms-blue); }
+.stat-card--purple .stat-card-value { color: #8a52d4; }
+.stat-card--green .stat-card-value { color: var(--ms-green-light); }
+
+.stat-card-label {
+  font-size: 10px;
+  font-weight: 500;
+  color: var(--text-tertiary);
+  text-transform: uppercase;
+  letter-spacing: 0.4px;
+}
+
+/* Connectivity progress bar */
+.stats-metric {
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+}
+
+.stats-metric-header {
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  font-size: 12px;
+  color: var(--text-secondary);
+}
+
+.stats-metric-header svg {
+  flex-shrink: 0;
+  color: var(--ms-yellow);
+}
+
+.stats-metric-value {
+  margin-left: auto;
+  font-weight: 600;
+  color: var(--ms-yellow);
+}
+
+.stats-progress-track {
+  height: 5px;
+  background: var(--bg-tertiary);
+  border-radius: 3px;
+  overflow: hidden;
+}
+
+.stats-progress-fill {
+  height: 100%;
+  background: linear-gradient(90deg, var(--ms-blue), var(--ms-purple));
+  border-radius: 3px;
+  transition: width var(--transition-normal);
+}
+
+/* Highlight rows (most connected, avg properties) */
+.stats-highlight {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 12px;
+  color: var(--text-secondary);
+  padding: 5px 8px;
+  background: var(--bg-tertiary);
+  border-radius: var(--radius-sm);
+}
+
+.stats-highlight svg {
+  flex-shrink: 0;
+  color: var(--ms-yellow);
+}
+
+.stats-highlight-label {
+  flex-shrink: 0;
+}
+
+.stats-highlight-value {
+  margin-left: auto;
+  font-weight: 600;
+  color: var(--text-primary);
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.stats-highlight-badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--ms-blue);
+  color: white;
+  font-size: 10px;
+  font-weight: 700;
+  border-radius: 10px;
+  padding: 1px 6px;
+  min-width: 20px;
+}
+
+/* Property type distribution */
+.stats-type-dist {
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+}
+
+.stats-type-dist-title {
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--text-tertiary);
+  text-transform: uppercase;
+  letter-spacing: 0.4px;
+  margin-bottom: 2px;
+}
+
+.stats-type-row {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 11px;
+}
+
+.stats-type-name {
+  width: 55px;
+  flex-shrink: 0;
+  color: var(--text-secondary);
+  text-transform: capitalize;
+}
+
+.stats-type-bar-track {
+  flex: 1;
+  height: 4px;
+  background: var(--bg-tertiary);
+  border-radius: 2px;
+  overflow: hidden;
+}
+
+.stats-type-bar-fill {
+  height: 100%;
+  background: var(--ms-blue);
+  border-radius: 2px;
+  min-width: 2px;
+  transition: width var(--transition-normal);
+}
+
+.stats-type-count {
+  width: 20px;
+  text-align: right;
+  color: var(--text-tertiary);
+  flex-shrink: 0;
+}
+
+/* Light theme adjustments for stat cards */
+.light-theme .stat-card--blue {
+  background: rgba(0, 120, 212, 0.08);
+}
+.light-theme .stat-card--purple {
+  background: rgba(92, 45, 145, 0.08);
+}
+.light-theme .stat-card--green {
+  background: rgba(16, 124, 16, 0.08);
+}
+.light-theme .stats-highlight {
+  background: var(--bg-tertiary);
+}
+
 .command-palette-input {
   flex: 1;
   background: transparent;
@@ -3969,4 +4284,250 @@ body {
   .learn-article-nav {
     flex-direction: column;
   }
+}
+
+/* ── Path Finder Panel ────────────────────────────────────────── */
+.pathfinder-panel {
+  flex-shrink: 0;
+  border-bottom: 1px solid var(--border-subtle);
+}
+
+.pathfinder-header {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 10px 16px;
+  background: transparent;
+  border: none;
+  color: var(--text-secondary);
+  cursor: pointer;
+  font-family: inherit;
+  transition: background var(--transition-fast);
+}
+
+.pathfinder-header:hover {
+  background: var(--bg-tertiary);
+}
+
+.pathfinder-title {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 12px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  color: var(--text-secondary);
+}
+
+.pathfinder-body {
+  padding: 12px 16px 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+/* From / To selects row */
+.pathfinder-selects {
+  display: flex;
+  align-items: flex-end;
+  gap: 6px;
+}
+
+.pathfinder-select-group {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.pathfinder-label {
+  font-size: 10px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.4px;
+  color: var(--text-tertiary);
+}
+
+.pathfinder-select {
+  width: 100%;
+  padding: 6px 8px;
+  background: var(--bg-tertiary);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-sm);
+  color: var(--text-primary);
+  font-family: inherit;
+  font-size: 12px;
+  cursor: pointer;
+}
+
+.pathfinder-select:focus {
+  outline: none;
+  border-color: var(--ms-blue);
+}
+
+.pathfinder-arrow-icon {
+  color: var(--text-tertiary);
+  flex-shrink: 0;
+  margin-bottom: 4px;
+}
+
+/* Action buttons */
+.pathfinder-actions {
+  display: flex;
+  gap: 6px;
+}
+
+.pathfinder-btn-find {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 5px;
+  padding: 7px 12px;
+  background: var(--ms-blue);
+  color: white;
+  border: none;
+  border-radius: var(--radius-sm);
+  font-family: inherit;
+  font-size: 12px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background var(--transition-fast);
+}
+
+.pathfinder-btn-find:hover:not(:disabled) {
+  background: var(--ms-blue-dark);
+}
+
+.pathfinder-btn-find:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.pathfinder-btn-clear {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 4px;
+  padding: 7px 10px;
+  background: var(--bg-tertiary);
+  color: var(--text-secondary);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-sm);
+  font-family: inherit;
+  font-size: 12px;
+  cursor: pointer;
+  transition: background var(--transition-fast);
+}
+
+.pathfinder-btn-clear:hover {
+  background: var(--bg-elevated);
+  color: var(--text-primary);
+}
+
+/* Messages */
+.pathfinder-message {
+  font-size: 12px;
+  padding: 8px 10px;
+  border-radius: var(--radius-sm);
+}
+
+.pathfinder-message--warn {
+  background: rgba(255, 185, 0, 0.1);
+  border: 1px solid rgba(255, 185, 0, 0.3);
+  color: var(--ms-yellow);
+}
+
+/* Result chain */
+.pathfinder-result {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.pathfinder-result-label {
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--text-tertiary);
+  text-transform: uppercase;
+  letter-spacing: 0.4px;
+}
+
+.pathfinder-chain {
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+}
+
+.pathfinder-chain-item {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+}
+
+/* Relationship connector */
+.pathfinder-chain-rel {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 2px 0 2px 20px;
+}
+
+.pathfinder-chain-rel-arrow {
+  width: 1px;
+  height: 16px;
+  background: var(--ms-blue);
+  position: relative;
+}
+
+.pathfinder-chain-rel-arrow::after {
+  content: '';
+  position: absolute;
+  bottom: -4px;
+  left: -3px;
+  border-left: 4px solid transparent;
+  border-right: 4px solid transparent;
+  border-top: 5px solid var(--ms-blue);
+}
+
+.pathfinder-chain-rel-name {
+  font-size: 10px;
+  font-style: italic;
+  color: var(--ms-blue);
+  font-weight: 500;
+}
+
+/* Entity node in chain */
+.pathfinder-chain-node {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 10px;
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--border-subtle);
+  background: var(--bg-tertiary);
+  width: 100%;
+}
+
+.pathfinder-chain-node--start {
+  border-color: var(--ms-green);
+  background: rgba(16, 124, 16, 0.1);
+}
+
+.pathfinder-chain-node--end {
+  border-color: var(--ms-orange);
+  background: rgba(216, 59, 1, 0.1);
+}
+
+.pathfinder-chain-icon {
+  font-size: 16px;
+  line-height: 1;
+}
+
+.pathfinder-chain-name {
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--text-primary);
 }


### PR DESCRIPTION
## Summary

Four new features and two UX polish fixes for the graph explorer, making it more informative, interactive, and visually professional.

---

## ✨ Ontology Insights Panel (`OntologyStatsPanel`)

A new collapsible panel at the top of the right sidebar with three live metric cards:

| Card | Value |
|------|-------|
| Entities | count of entity types |
| Relationships | count of relationships |
| Properties | total properties across all entities |

Styled with Microsoft Fluent color tokens. Updates reactively when the ontology changes.
<img width="358" height="150" alt="image" src="https://github.com/user-attachments/assets/b66067f1-5dd9-487a-99fa-348eb8a86b1f" />

---

## 🔍 Relationship Path Finder (`PathFinderPanel`)

Finds the shortest connection between any two entities using BFS traversal.

- Pick **From** / **To** entities from dropdowns → click **Find Path**
- Result renders as a visual hop chain with relationship names:
  `🟢 Department → for_department → Assignment → has_review → 🟠 PerformanceReview`
- Shows hop count (e.g. *Shortest path — 3 hops*)
- Highlights the **full path** on the graph (nodes + edges glow yellow)
- Highlights applied atomically via a new `setHighlights(entityIds, relIds)` store action to prevent double-render flicker
- Warning shown when no path exists; **Clear** resets highlights
<img width="1519" height="841" alt="image" src="https://github.com/user-attachments/assets/9c309011-4ebf-43fc-84a9-dbf25eacbe63" />

---

## 🎯 Focus / Neighbourhood Mode

- **Double-click any node** → dims everything except that entity and its direct connections
- **Double-click again** or **click the background** to exit
- Blue *"Focus mode"* pill badge at the top of the canvas shows active state
- Correctly co-exists with selection highlighting and path highlights
<img width="1071" height="843" alt="image" src="https://github.com/user-attachments/assets/7c103d2d-de0c-466e-bc39-8ea18d8f6938" />

---

## 📥 Graph PNG Export

- **Download** button added to the graph controls toolbar
- Exports full canvas at 2× resolution as a `.png`
- Filename derived from the ontology name (e.g. `healthcare-graph.png`)
- <img width="294" height="146" alt="image" src="https://github.com/user-attachments/assets/643b7ee9-6342-4885-9088-cf98480537b6" />


---

## 🏷️ Edge Label Readability (polish)

- Semi-transparent rounded background added behind every edge label — no more bleed into adjacent edges on dense graphs
- Labels capped at 120 px with ellipsis for long names
- Background color follows dark/light theme

---

## 🗂️ Inspector Relationship Layout (polish)

Relationship rows in the Entity Inspector now use a two-line stacked layout:
has_assignment → 📋 Assignment
one-to-many
<img width="337" height="263" alt="image" src="https://github.com/user-attachments/assets/eb4554b7-0b15-4f46-929e-ce425b6580f0" />


Eliminates overflow/wrapping on long relationship or entity names.

---
## 📜 Universal Right Sidebar Scroller (polish)

Previously, individual panels (Search & Filter, Inspector) each had their own internal scroll containers which caused panels to get cut off and hidden behind each other.

- Removed all per-panel overflow constraints
- Made `.right-sidebar` the single scroll container (`overflow-y: auto`)
- All panels now render at their natural height and the sidebar scrolls as one unit — no more hidden content

---
## Testing

- Verified across `healthcare`, `ecommerce`, `cosmic-coffee`, `baby-routine` (8 entities, 8 relationships)
- Dark mode and light mode
- `npx tsc -b` — zero errors
- `npm run build` — clean production build