### PR TITLE
docs: clarify which docs are part of the published guide set

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,6 +235,8 @@ Ontology-Playground/
 
 ## Documentation
 
+The table below lists the main end-user and contributor guides. Internal planning notes (for example, `docs/TODO-*.md`) are intentionally not part of the published documentation set.
+
 | Guide | Description |
 |-------|-------------|
 | [Ontology Authoring Guide](docs/authoring-guide.md) | How to create ontologies that work well in the Playground — field-by-field reference, best practices, and a step-by-step walkthrough |


### PR DESCRIPTION
Clarifies that the README documentation table is intended to list the published guides, while internal planning notes such as `docs/TODO-*.md` are not part of the public docs set.