### PR TITLE
fix: allow self-referencing relationships (#64)

### DIFF
--- a/docs/TODO-full-ontology-format.md
+++ b/docs/TODO-full-ontology-format.md
@@ -265,11 +265,13 @@ Fabric IQ enforces strict naming rules that the Playground currently ignores.
 - [x] Show a clear error message explaining the cross-entity constraint
 
 ### 7.3 Relationship type constraints
-- [x] Source and target entity types must be **distinct** (no self-referencing
-  relationships in Fabric IQ)
-- [x] Validate in the designer when creating a relationship
-- [ ] Show a warning when importing an RDF file with self-referencing
-  relationships
+- [x] ~~Source and target entity types must be **distinct** (no self-referencing
+  relationships in Fabric IQ)~~ **Reverted (#64):** Fabric Ontology *does*
+  support self-referencing relationships (e.g., `Employee reportsTo Employee`),
+  so the designer now allows `source == target`.
+- [x] Self-referencing relationships render as graph self-loops (Cytoscape)
+- [x] "Add relationship" works with a single entity type (defaults to a
+  self-reference)
 
 ---
 

--- a/src/components/designer/RelationshipForm.test.tsx
+++ b/src/components/designer/RelationshipForm.test.tsx
@@ -1,0 +1,65 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { RelationshipForm } from './RelationshipForm';
+import { useDesignerStore } from '../../store/designerStore';
+
+// Reset the draft between tests
+beforeEach(() => {
+  useDesignerStore.getState().resetDraft();
+});
+
+describe('RelationshipForm — self-referencing relationships (issue #64)', () => {
+  it('prompts to create an entity and disables Add when there are no entities', () => {
+    render(<RelationshipForm />);
+
+    expect(screen.getByText('Create at least one entity first.')).toBeInTheDocument();
+    expect(
+      screen.getByTitle('Create at least one entity to add a relationship'),
+    ).toBeDisabled();
+  });
+
+  it('enables Add with a single entity and creates a self-referencing relationship', () => {
+    useDesignerStore.getState().addEntity();
+    const entityId = useDesignerStore.getState().ontology.entityTypes[0].id;
+
+    render(<RelationshipForm />);
+
+    const addBtn = screen.getByTitle('Add relationship');
+    expect(addBtn).toBeEnabled();
+
+    fireEvent.click(addBtn);
+
+    const rels = useDesignerStore.getState().ontology.relationships;
+    expect(rels).toHaveLength(1);
+    expect(rels[0].from).toBe(entityId);
+    expect(rels[0].to).toBe(entityId);
+  });
+
+  it('defaults the target to a second entity when more than one exists', () => {
+    useDesignerStore.getState().addEntity();
+    useDesignerStore.getState().addEntity();
+    const [first, second] = useDesignerStore.getState().ontology.entityTypes;
+
+    render(<RelationshipForm />);
+
+    fireEvent.click(screen.getByTitle('Add relationship'));
+
+    const rel = useDesignerStore.getState().ontology.relationships[0];
+    expect(rel.from).toBe(first.id);
+    expect(rel.to).toBe(second.id);
+    expect(rel.from).not.toBe(rel.to);
+  });
+
+  it('does not show a "must be different" warning for a self-referencing relationship', () => {
+    useDesignerStore.getState().addEntity();
+    const entityId = useDesignerStore.getState().ontology.entityTypes[0].id;
+    useDesignerStore.getState().addRelationship(entityId, entityId);
+    const relId = useDesignerStore.getState().ontology.relationships[0].id;
+    useDesignerStore.getState().selectRelationship(relId);
+
+    render(<RelationshipForm />);
+
+    expect(screen.queryByText(/source and target/i)).toBeNull();
+    expect(screen.queryByText(/self-referencing relationship/i)).toBeNull();
+  });
+});

--- a/src/components/designer/RelationshipForm.tsx
+++ b/src/components/designer/RelationshipForm.tsx
@@ -29,8 +29,12 @@ export function RelationshipForm() {
   const entities = ontology.entityTypes;
 
   const handleAdd = () => {
-    if (entities.length < 2) return;
-    addRelationship(entities[0].id, entities[1].id);
+    if (entities.length < 1) return;
+    // Default the target to a second entity when one exists; otherwise create a
+    // self-referencing relationship on the only entity (Fabric supports these).
+    const from = entities[0].id;
+    const to = entities[1]?.id ?? entities[0].id;
+    addRelationship(from, to);
   };
 
   return (
@@ -40,8 +44,8 @@ export function RelationshipForm() {
         <button
           className="designer-add-btn"
           onClick={handleAdd}
-          disabled={entities.length < 2}
-          title={entities.length < 2 ? 'Need at least 2 entities to create a relationship' : 'Add relationship'}
+          disabled={entities.length < 1}
+          title={entities.length < 1 ? 'Create at least one entity to add a relationship' : 'Add relationship'}
         >
           <Plus size={14} /> Add
         </button>
@@ -49,8 +53,8 @@ export function RelationshipForm() {
 
       {ontology.relationships.length === 0 && (
         <div className="designer-empty">
-          {entities.length < 2
-            ? 'Create at least two entities first.'
+          {entities.length < 1
+            ? 'Create at least one entity first.'
             : 'No relationships yet. Click "Add" to create one.'}
         </div>
       )}
@@ -83,11 +87,6 @@ export function RelationshipForm() {
 
             {isSelected && (
               <div className="designer-rel-body">
-                {rel.from === rel.to && (
-                  <div className="designer-field-hint error" style={{ marginBottom: 8 }}>
-                    ⚠️ Self-referencing relationship — Fabric IQ requires source and target entity types to be different.
-                  </div>
-                )}
                 {/* Name */}
                 <label className="designer-field">
                   <span>Name</span>

--- a/src/store/designerStore.test.ts
+++ b/src/store/designerStore.test.ts
@@ -156,20 +156,68 @@ describe('validateOntology', () => {
     expect(validateOntology(ontology).some((e) => e.message.includes('must be string or integer'))).toBe(true);
   });
 
-  // §7.3 — Self-referencing relationship
-  it('reports self-referencing relationships', () => {
+  // §7.3 — Self-referencing relationships are allowed (issue #64)
+  it('allows self-referencing relationships (no validation error)', () => {
     const ontology: Ontology = {
       name: 'Test',
       description: '',
       entityTypes: [
-        { id: 'e1', name: 'Foo', description: '', icon: '📦', color: '#000',
+        { id: 'e1', name: 'Employee', description: '', icon: '📦', color: '#000',
           properties: [{ name: 'id', type: 'string', isIdentifier: true }] },
       ],
       relationships: [
-        { id: 'r1', name: 'selfRef', from: 'e1', to: 'e1', cardinality: 'one-to-many' },
+        { id: 'r1', name: 'reportsTo', from: 'e1', to: 'e1', cardinality: 'many-to-one' },
       ],
     };
-    expect(validateOntology(ontology).some((e) => e.message.includes('self-referencing'))).toBe(true);
+    const errors = validateOntology(ontology);
+    expect(errors.some((e) => e.message.includes('self-referencing'))).toBe(false);
+    expect(errors.some((e) => e.message.includes('source and target'))).toBe(false);
+  });
+
+  it('passes for a valid ontology containing a self-referencing relationship', () => {
+    const ontology: Ontology = {
+      name: 'Org',
+      description: 'An org chart',
+      entityTypes: [
+        { id: 'e1', name: 'Employee', description: '', icon: '👤', color: '#0078D4',
+          properties: [{ name: 'id', type: 'string', isIdentifier: true }] },
+      ],
+      relationships: [
+        { id: 'r1', name: 'reportsTo', from: 'e1', to: 'e1', cardinality: 'many-to-one' },
+      ],
+    };
+    expect(validateOntology(ontology)).toEqual([]);
+  });
+
+  it('still flags a self-referencing relationship that points to a missing entity', () => {
+    const ontology: Ontology = {
+      name: 'Test',
+      description: '',
+      entityTypes: [
+        { id: 'e1', name: 'Employee', description: '', icon: '📦', color: '#000',
+          properties: [{ name: 'id', type: 'string', isIdentifier: true }] },
+      ],
+      relationships: [
+        { id: 'r1', name: 'reportsTo', from: 'ghost', to: 'ghost', cardinality: 'one-to-many' },
+      ],
+    };
+    expect(validateOntology(ontology).some((e) => e.message.includes("doesn't exist"))).toBe(true);
+  });
+
+  it('allows multiple self-referencing relationships on the same entity', () => {
+    const ontology: Ontology = {
+      name: 'Test',
+      description: '',
+      entityTypes: [
+        { id: 'e1', name: 'Person', description: '', icon: '👤', color: '#0078D4',
+          properties: [{ name: 'id', type: 'string', isIdentifier: true }] },
+      ],
+      relationships: [
+        { id: 'r1', name: 'manages', from: 'e1', to: 'e1', cardinality: 'one-to-many' },
+        { id: 'r2', name: 'mentors', from: 'e1', to: 'e1', cardinality: 'one-to-many' },
+      ],
+    };
+    expect(validateOntology(ontology)).toEqual([]);
   });
 });
 
@@ -286,6 +334,16 @@ describe('useDesignerStore actions', () => {
     expect(rel.from).toBe(e1);
     expect(rel.to).toBe(e2);
     expect(rel.cardinality).toBe('one-to-many');
+  });
+
+  it('addRelationship can create a self-referencing relationship', () => {
+    useDesignerStore.getState().addEntity();
+    const e1 = useDesignerStore.getState().ontology.entityTypes[0].id;
+    useDesignerStore.getState().addRelationship(e1, e1);
+    const rel = useDesignerStore.getState().ontology.relationships[0];
+    expect(rel.from).toBe(e1);
+    expect(rel.to).toBe(e1);
+    expect(validateOntology(useDesignerStore.getState().ontology).some((e) => e.message.includes('self-referencing'))).toBe(false);
   });
 
   it('updateRelationship updates fields', () => {

--- a/src/store/designerStore.ts
+++ b/src/store/designerStore.ts
@@ -43,7 +43,6 @@ export function validateOntology(ontology: Ontology): ValidationError[] {
   }
 
   const entityIds = new Set<string>();
-  const entityNameById = new Map<string, string>();
 
   // Cross-entity property name → type map for uniqueness check (§7.2)
   const propNameTypeMap = new Map<string, { type: string; entityName: string }>();
@@ -56,7 +55,6 @@ export function validateOntology(ontology: Ontology): ValidationError[] {
       errors.push({ message: `Two entities share the same ID "${e.id}". Rename one of them.`, entityId: e.id });
     } else {
       entityIds.add(e.id);
-      entityNameById.set(e.id, label);
     }
     if (!e.name) {
       errors.push({ message: 'One of your entities has no name. Give it a name.', entityId: e.id });
@@ -126,15 +124,6 @@ export function validateOntology(ontology: Ontology): ValidationError[] {
       const toLabel = r.to || '(none)';
       errors.push({
         message: `"${label}" points to "${toLabel}" which doesn't exist. Pick a valid target entity.`,
-        relationshipId: r.id,
-      });
-    }
-
-    // §7.3 — Self-referencing relationship warning
-    if (r.from && r.to && r.from === r.to) {
-      const entityLabel = entityNameById.get(r.from) || r.from;
-      errors.push({
-        message: `"${label}" is a self-referencing relationship on "${entityLabel}". Fabric IQ requires source and target entity types to be different.`,
         relationshipId: r.id,
       });
     }


### PR DESCRIPTION
Fixes #64.

## Problem
The designer blocked relationships where the source and target are the same entity type, surfacing a validation error ("Fabric IQ requires source and target entity types to be different"). But Fabric Ontology **does** support self-referencing relationships (e.g., `Employee reportsTo Employee`), as shown in the issue.

## Changes
- Remove the §7.3 "source and target must be distinct" validation error in `designerStore` (and drop the now-unused `entityNameById` map).
- Remove the inline "must be different" warning in `RelationshipForm`.
- Let **Add relationship** work with a single entity type, defaulting to a self-reference when no second entity exists.
- Tests: replace the old validation test and add a battery (validation + store action) plus a new `RelationshipForm` component test.
- Docs: update `docs/TODO-full-ontology-format.md` §7.3 to record the reversal.

The graph layer needs no change — Cytoscape renders `source == target` edges as self-loops natively.

## Testing
- `npx vitest run` — all tests pass (incl. the new self-referencing battery).
- `npm run build` — succeeds.
