### PR TITLE
Add multi-theme support (Aurora, Crimson) with theme-aware graphs

### DIFF
--- a/.github/skills/theme-authoring/SKILL.md
+++ b/.github/skills/theme-authoring/SKILL.md
@@ -1,0 +1,83 @@
+---
+name: theme-authoring
+description: "Add a new color theme to the Ontology Playground. Use when someone wants to create, author, or plug in a theme, palette, color scheme, dark mode, or light mode, or add an entry to the theme picker. Covers the appStore registration plus the CSS token block."
+---
+
+# Theme Authoring Skill
+
+## Goal
+
+Plug a new color theme into the Playground so it appears in the header theme
+picker, is remembered across sessions, and themes every surface (main graph,
+designer preview, learn pages) — with no component or graph-rendering edits.
+
+## Read First
+
+1. [`docs/theme-authoring-guide.md`](../../../docs/theme-authoring-guide.md) — full architecture, token table, gotchas, worked example.
+2. [`src/store/appStore.ts`](../../../src/store/appStore.ts) — `ThemeId`, `THEME_OPTIONS`, `DARK_BASED_THEMES`, `isDarkTheme`, `themeClass`.
+3. [`src/styles/app.css`](../../../src/styles/app.css) — the `:root` / `.light-theme` / `.theme-aurora` / `.theme-crimson` token blocks (copy the nearest one).
+
+## Intake Questions
+
+Ask the user:
+
+1. Theme **id** (lowercase, e.g. `indigo`) and **display label** (e.g. `Indigo`)?
+2. **Dark-based or light-based?** (Determines `DARK_BASED_THEMES` membership and which block to copy.)
+3. **Accent / signature color** (used for the picker swatch and `--ms-blue*` / `--info`)?
+4. Any specific surface, text, or graph colors, or should they be derived from the accent?
+
+## Procedure
+
+Make all edits in [`src/store/appStore.ts`](../../../src/store/appStore.ts) and
+[`src/styles/app.css`](../../../src/styles/app.css). The guide's
+"Add a theme in six steps" section has copy-paste snippets.
+
+1. Add the id to the `ThemeId` union.
+2. Add a `THEME_OPTIONS` entry: `{ id, label, swatch }` (swatch = accent hex).
+3. If **dark-based**, add the id to `DARK_BASED_THEMES`. If light-based, leave it out.
+4. Add a `themeClass()` case:
+   - dark-based → `return 'theme-<id>';`
+   - light-based → `return 'light-theme theme-<id>';` (layer over the light base).
+5. Add a `.theme-<id>` block in `app.css` by copying `.theme-aurora` (dark) or
+   `.theme-crimson` (light) and retuning the tokens.
+6. Verify (see below).
+
+## Critical Rules
+
+- **Opaque canvas base for light themes.** `--chess-square-light` is the graph
+  canvas's solid backdrop. The theme class sits on `.app-container`, not `<body>`,
+  and `<body>` stays dark (`#1B1B1B`). A translucent `--chess-square-light` lets
+  the dark body bleed through → dark canvas + unreadable labels. Use an opaque
+  light color (e.g. `#FBF7F8`), not `rgba(..., 0.03)`. (Guide → Gotcha 1.)
+- **Graph colors are CSS-driven.** Define `--graph-bg`, `--graph-node-text`,
+  `--graph-edge-color`, `--graph-edge-text` in the block; the graph and designer
+  read them at runtime. No `.tsx` edits. Tune for contrast against `--graph-bg`.
+- **Register dark themes** in `DARK_BASED_THEMES` so `darkMode` is correct
+  (graph fallback, label backplate, PNG export bg).
+- **Don't introduce brand names** in ids, labels, comments, or commits. Use
+  generic palette names (e.g. Aurora, Crimson, Indigo, Sand).
+
+## Person Names
+
+If any example data, docs, or sample instances need person names, use the
+`name-generator` skill — do not invent names.
+
+## Validate
+
+```bash
+npm run dev          # switch to the theme in the header; check graph, designer, learn pages
+npx tsc --noEmit     # the ThemeId union change is type-checked here
+npm run build        # full build
+```
+
+If `npm run build` only changed `public/learn.json` (a timestamp), revert it:
+`git checkout -- public/learn.json`.
+
+## Done Criteria
+
+- New swatch + label appear in the picker; selection check mark tracks state.
+- Theme persists across reload (`localStorage['theme']`).
+- Main graph, designer preview, and learn pages are legible in the new theme;
+  the graph canvas backdrop matches the theme (Gotcha 1 satisfied).
+- Dark, Light, Aurora, Crimson unchanged.
+- `tsc --noEmit` and `npm run build` pass; no brand references introduced.

--- a/README.md
+++ b/README.md
@@ -248,6 +248,7 @@ The table below lists the main end-user and contributor guides. Internal plannin
 | [Embed Security](docs/embed-security.md) | Security model for the embeddable widget |
 | [Learning Content Guide](docs/learn-content-guide.md) | How to author courses, articles, quizzes, and ontology embeds for the Ontology School |
 | [Ontology School Review Workflow](docs/ontology-school-review-workflow.md) | Human review and approval flow for school lesson content |
+| [Theme Authoring Guide](docs/theme-authoring-guide.md) | How to plug a new color theme into the Playground — token contract, the appStore + CSS steps, and contrast gotchas |
 
 ## AI Agent Quickstart
 

--- a/docs/theme-authoring-guide.md
+++ b/docs/theme-authoring-guide.md
@@ -1,0 +1,288 @@
+# Theme Authoring Guide
+
+How to plug a new color theme into the Ontology Playground.
+
+Theming is **CSS-variable based**. A theme is a named set of CSS custom-property
+values that override the defaults, plus a small amount of registration in the
+Zustand store so the theme appears in the picker and is remembered across
+sessions. You do **not** touch the graph, designer, or learn components to add a
+theme — they read their colors from the CSS variables at runtime.
+
+---
+
+## Architecture at a glance
+
+There are four moving parts. The first three live in
+[`src/store/appStore.ts`](../src/store/appStore.ts); the fourth lives in
+[`src/styles/app.css`](../src/styles/app.css).
+
+| Part | What it does |
+| --- | --- |
+| `ThemeId` union | The set of valid theme ids. |
+| `THEME_OPTIONS` | Drives the header theme picker (id, label, swatch). |
+| `themeClass(theme)` | Maps a theme id → the CSS class(es) on the themed root. |
+| CSS token block | The actual color values, keyed on that class. |
+
+Two helpers tie it together:
+
+- `isDarkTheme(theme)` / `DARK_BASED_THEMES` — declares whether a theme uses the
+  dark base palette. This sets the store's derived `darkMode` flag, which drives
+  graph render fallbacks, node-label backplates, and the PNG-export background.
+- `setTheme(theme)` — persists the choice to `localStorage['theme']` and updates
+  `{ theme, darkMode }`.
+
+### Where the theme class is applied
+
+`themeClass(theme)` is attached to the root element of each top-level surface —
+**not** to `<body>`:
+
+- [`src/App.tsx`](../src/App.tsx) → `app-container ${themeClass(theme)}`
+- [`src/components/OntologyDesigner.tsx`](../src/components/OntologyDesigner.tsx) → `designer-page ${themeClass(theme)}`
+- [`src/components/LearnPage.tsx`](../src/components/LearnPage.tsx) → `learn-page ${themeClass(theme)}`
+
+`:root` (and therefore `<body>`) always carries the **Dark** defaults. See
+[Gotcha 1](#gotcha-1-the-body-stays-dark) for why that matters.
+
+### How `themeClass` layers classes
+
+```ts
+export function themeClass(theme: ThemeId): string {
+  switch (theme) {
+    case 'light':   return 'light-theme';
+    case 'aurora':  return 'theme-aurora';
+    case 'crimson': return 'light-theme theme-crimson'; // layered
+    default:        return ''; // dark = :root defaults
+  }
+}
+```
+
+`crimson` returns **two** classes. `.light-theme` supplies the full set of light
+values; `.theme-crimson` only overrides the handful of tokens that make it
+crimson. A light-based theme should do the same so you don't re-specify every
+token. A dark-based theme can return a single class because `:root` is already
+the dark base.
+
+---
+
+## The token contract
+
+`:root` in [`src/styles/app.css`](../src/styles/app.css) defines every token.
+A theme block overrides the subset that should change. Anything you omit falls
+back to `:root` (for dark-based themes) or to `.light-theme` (for themes layered
+over it).
+
+| Group | Tokens | Notes |
+| --- | --- | --- |
+| Accent | `--ms-blue`, `--ms-blue-dark`, `--ms-blue-light`, `--info` | Primary accent used across buttons, links, highlights. Override these to re-brand the accent color. |
+| Surfaces | `--bg-primary`, `--bg-secondary`, `--bg-tertiary`, `--bg-elevated` | Page and panel backgrounds, lightest → most elevated. |
+| Text | `--text-primary`, `--text-secondary`, `--text-tertiary` | Foreground text, primary → muted. |
+| Borders | `--border-color`, `--border-subtle` | Panel/control borders. |
+| Shadow | `--shadow-glow` | Accent glow; tint it to match the accent. |
+| Graph | `--graph-bg`, `--graph-node-text`, `--graph-edge-color`, `--graph-edge-text` | Read at runtime by the graph + designer preview. **Tune these for contrast against `--graph-bg`.** |
+| Canvas checker | `--chess-square-dark`, `--chess-square-light` | The graph canvas backdrop pattern. `--chess-square-light` is the **solid base** — see [Gotcha 1](#gotcha-1-the-body-stays-dark). |
+| About links | `--about-link-color`, `--about-link-hover-color` | Links on the About screen. |
+
+> The accent tokens are historically named `--ms-*`. Treat them as generic accent
+> variables — the name is incidental.
+
+---
+
+## Add a theme in six steps
+
+The running example is a dark-based theme called **Indigo**. Where a light-based
+theme differs, it's called out inline.
+
+### 1. Extend the `ThemeId` union — `appStore.ts`
+
+```ts
+export type ThemeId = 'dark' | 'light' | 'aurora' | 'crimson' | 'indigo';
+```
+
+### 2. Register it in `THEME_OPTIONS` — `appStore.ts`
+
+```ts
+export const THEME_OPTIONS: { id: ThemeId; label: string; swatch: string }[] = [
+  { id: 'dark',    label: 'Dark',    swatch: '#1B1B1B' },
+  { id: 'light',   label: 'Light',   swatch: '#F5F5F5' },
+  { id: 'aurora',  label: 'Aurora',  swatch: '#2AAA92' },
+  { id: 'crimson', label: 'Crimson', swatch: '#D6002A' },
+  { id: 'indigo',  label: 'Indigo',  swatch: '#4F46E5' }, // swatch = the dot in the picker
+];
+```
+
+The `swatch` is the color dot shown next to the label in the picker menu — use
+the theme's signature accent.
+
+### 3. Declare dark-vs-light — `appStore.ts`
+
+Dark-based themes go in `DARK_BASED_THEMES`:
+
+```ts
+const DARK_BASED_THEMES: ThemeId[] = ['dark', 'aurora', 'indigo'];
+```
+
+A **light-based** theme is left out of this list (so `darkMode` becomes `false`).
+
+### 4. Map the id to a CSS class — `appStore.ts`
+
+```ts
+export function themeClass(theme: ThemeId): string {
+  switch (theme) {
+    case 'light':   return 'light-theme';
+    case 'aurora':  return 'theme-aurora';
+    case 'crimson': return 'light-theme theme-crimson';
+    case 'indigo':  return 'theme-indigo';                  // dark-based: single class
+    // a light-based theme would return 'light-theme theme-<id>'
+    default:        return '';
+  }
+}
+```
+
+### 5. Add the CSS token block — `app.css`
+
+Copy the nearest existing block (`.theme-aurora` for dark, `.theme-crimson` for
+light) and retune. Place it after the existing theme blocks.
+
+```css
+/* Indigo theme — deep indigo base with violet accents (dark) */
+.theme-indigo {
+  --ms-blue: #6366F1;
+  --ms-blue-dark: #4F46E5;
+  --ms-blue-light: #818CF8;
+  --info: #6366F1;
+
+  --bg-primary: #15172B;
+  --bg-secondary: #1C1F3A;
+  --bg-tertiary: #262A4D;
+  --bg-elevated: #20233F;
+  --text-primary: #EEF0FF;
+  --text-secondary: #B9BEE6;
+  --text-tertiary: #8489B8;
+  --border-color: #343A66;
+  --border-subtle: #262A4D;
+
+  --shadow-glow: 0 0 20px rgba(99, 102, 241, 0.35);
+
+  --graph-bg: #14162A;
+  --graph-node-text: #CDD2FF;
+  --graph-edge-color: #5A5FA0;
+  --graph-edge-text: #9AA0D6;
+
+  --chess-square-dark: rgba(40, 44, 90, 0.85);
+  --chess-square-light: rgba(30, 33, 70, 0.65);
+  --about-link-color: #A5B4FC;
+  --about-link-hover-color: #C7D2FE;
+}
+```
+
+For a **light-based** theme, override `.theme-<id>` to layer over `.light-theme`,
+and make `--chess-square-light` an **opaque** light color (see Gotcha 1).
+
+### 6. Verify
+
+Run the [testing checklist](#testing-checklist).
+
+That's it — the graph, designer preview, and learn pages pick up the new
+`--graph-*` and surface tokens automatically.
+
+---
+
+## Gotchas
+
+### Gotcha 1: the `<body>` stays dark
+
+The theme class is applied to `.app-container` / `.designer-page` /
+`.learn-page`, **not** `<body>`. `<body>` keeps the `:root` (Dark) background
+(`#1B1B1B`). Any element with a **transparent or semi-transparent background**
+lets that dark body show through.
+
+This bites the **graph canvas**. Its backdrop is the chess pattern in
+`.graph-container`, whose solid base is `--chess-square-light`:
+
+```css
+.graph-container {
+  background-image: /* squares painted with var(--chess-square-dark) */;
+  background-color: var(--chess-square-light); /* the solid base */
+}
+```
+
+If `--chess-square-light` is translucent on a light theme, the dark body bleeds
+through and the canvas reads dark — making dark node labels unreadable. (This was
+a real bug in Crimson.)
+
+**Rule:** for a light theme, `--chess-square-light` must be an **opaque** light
+color. Compare:
+
+```css
+/* WRONG — translucent base, dark body shows through */
+--chess-square-light: rgba(214, 0, 42, 0.03);
+
+/* RIGHT — opaque light base */
+--chess-square-light: #FBF7F8;
+```
+
+Dark-based themes can use translucent values because the body behind them is
+already dark.
+
+### Gotcha 2: graph colors come from CSS, not props
+
+`OntologyGraph` and the designer's `GraphPreview` read `--graph-node-text`,
+`--graph-edge-color`, and `--graph-edge-text` from `getComputedStyle` and
+re-read them when the active `theme` changes. So **defining the `--graph-*`
+tokens in your theme block is all you need** — no component or TypeScript edits.
+Tune them for contrast against your `--graph-bg`.
+
+### Gotcha 3: register dark-based themes in `DARK_BASED_THEMES`
+
+`isDarkTheme()` feeds the store's `darkMode` flag, which sets the initial graph
+fallback color, the node-label backplate (`text-background-color`), and the PNG
+export background. If a dark theme is missing from `DARK_BASED_THEMES`, the graph
+will briefly fall back to light defaults and labels can get a light backplate.
+
+### Gotcha 4: layer light themes over `.light-theme`
+
+Returning `'light-theme theme-<id>'` from `themeClass` lets your block inherit
+every light token and override only what's distinctive. Returning a single class
+means you must re-specify the full token set or inherit Dark defaults by mistake.
+
+---
+
+## Testing checklist
+
+```bash
+npm run dev          # then switch to the new theme in the header picker
+```
+
+Check, in the new theme:
+
+- [ ] **Main graph** (home, ontology loaded): node labels, edge labels, and edges
+      are legible against `--graph-bg`; the canvas backdrop matches the theme
+      (not a stray dark/black panel — Gotcha 1).
+- [ ] **Designer** (`#/designer`, load a template, Graph tab): preview is legible.
+- [ ] **Learn pages** (`#/learn`): surfaces and text read correctly.
+- [ ] **Picker**: the new swatch + label appear and the check mark tracks
+      selection.
+- [ ] **Persistence**: reload the page — the theme is remembered.
+- [ ] **No regressions**: Dark, Light, Aurora, and Crimson still look correct.
+
+Then:
+
+```bash
+npx tsc --noEmit     # type-check (the ThemeId union change is covered here)
+npm run build        # full production build
+```
+
+> `npm run build` regenerates `public/learn.json` with a fresh timestamp. If that
+> is the only change there, revert it before committing:
+> `git checkout -- public/learn.json`.
+
+---
+
+## Files you touch
+
+| File | Change |
+| --- | --- |
+| [`src/store/appStore.ts`](../src/store/appStore.ts) | `ThemeId`, `THEME_OPTIONS`, `DARK_BASED_THEMES`, `themeClass()` |
+| [`src/styles/app.css`](../src/styles/app.css) | one `.theme-<id>` token block |
+
+Everything else (graph, designer, learn, picker UI) adapts automatically.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -26,13 +26,13 @@ import {
   PathFinderPanel
 } from './components';
 import type { CommandItem } from './components';
-import { useAppStore } from './store/appStore';
+import { useAppStore, themeClass, THEME_OPTIONS } from './store/appStore';
 import { useDesignerStore } from './store/designerStore';
 import { useRoute } from './hooks/useRoute';
 import { navigate } from './lib/router';
 import { decodeSharePayload } from './lib/shareCodec';
 import type { Catalogue } from './types/catalogue';
-import { Search, MessageSquare, Info, Compass, LayoutGrid, PenTool, BookOpen, FileJson, HelpCircle, Database, Sun, Moon, FileText } from 'lucide-react';
+import { Search, MessageSquare, Info, Compass, LayoutGrid, PenTool, BookOpen, FileJson, HelpCircle, Database, Palette, FileText } from 'lucide-react';
 import './styles/app.css';
 
 const AI_BUILDER_ENABLED = import.meta.env.VITE_ENABLE_AI_BUILDER === 'true';
@@ -56,7 +56,7 @@ function App() {
   const [toast, setToast] = useState<{ message: string; icon: string } | null>(null);
   const [mobilePanel, setMobilePanel] = useState<'graph' | 'quests' | 'inspector' | 'query'>('graph');
   const [showCommandPalette, setShowCommandPalette] = useState(false);
-  const { darkMode, earnedBadges, loadOntology, toggleDarkMode } = useAppStore();
+  const { theme, setTheme, earnedBadges, loadOntology } = useAppStore();
 
   // Show toast when a new badge is earned
   useEffect(() => {
@@ -133,6 +133,12 @@ function App() {
 
   const openLearn = useCallback(() => navigate({ page: 'learn' }), []);
 
+  const cycleTheme = useCallback(() => {
+    const idx = THEME_OPTIONS.findIndex((t) => t.id === theme);
+    const next = THEME_OPTIONS[(idx + 1) % THEME_OPTIONS.length];
+    setTheme(next.id);
+  }, [theme, setTheme]);
+
   // ── Global keyboard shortcuts ──────────────────────────
   useEffect(() => {
     const handler = (e: KeyboardEvent) => {
@@ -170,8 +176,8 @@ function App() {
     { id: 'about', label: 'About & Trademark Notice', icon: <Info size={18} />, action: () => setShowAbout(true) },
     { id: 'help', label: 'Help', icon: <HelpCircle size={18} />, shortcut: '?', action: () => setShowHelp(true) },
     { id: 'data-sources', label: 'Data Sources', icon: <Database size={18} />, action: () => setShowDataSources(true) },
-    { id: 'theme', label: darkMode ? 'Switch to Light Mode' : 'Switch to Dark Mode', icon: darkMode ? <Sun size={18} /> : <Moon size={18} />, action: toggleDarkMode },
-  ], [darkMode, openGallery, openDesigner, openLearn, toggleDarkMode]);
+    { id: 'theme', label: 'Switch Theme', icon: <Palette size={18} />, action: cycleTheme },
+  ], [openGallery, openDesigner, openLearn, cycleTheme]);
 
   // Full-page views
   if (route.page === 'designer') {
@@ -182,7 +188,7 @@ function App() {
   }
 
   return (
-    <div className={`app-container ${darkMode ? '' : 'light-theme'}`}>
+    <div className={`app-container ${themeClass(theme)}`}>
       <Header 
         onAboutClick={() => setShowAbout(true)}
         onHelpClick={() => setShowHelp(true)} 

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,10 +1,10 @@
 import { useState, useRef, useEffect } from 'react';
-import { useAppStore } from '../store/appStore';
+import { useAppStore, THEME_OPTIONS } from '../store/appStore';
 import { useRoute } from '../hooks/useRoute';
 import { routeToHash } from '../lib/router';
 import { encodeSharePayload } from '../lib/shareCodec';
 import { serializeToRDF } from '../lib/rdf/serializer';
-import { Moon, Sun, Database, Trophy, HelpCircle, FileJson, LayoutGrid, Sparkles, FileText, Share2, PenTool, BookOpen, Menu, X, Download, Info } from 'lucide-react';
+import { Palette, Check, Database, Trophy, HelpCircle, FileJson, LayoutGrid, Sparkles, FileText, Share2, PenTool, BookOpen, Menu, X, Download, Info } from 'lucide-react';
 
 interface HeaderProps {
   onAboutClick: () => void;
@@ -19,11 +19,13 @@ interface HeaderProps {
 }
 
 export function Header({ onAboutClick, onHelpClick, onDataSourcesClick, onImportExportClick, onGalleryClick, onDesignerClick, onLearnClick, onNLBuilderClick, onSummaryClick }: HeaderProps) {
-  const { darkMode, toggleDarkMode, totalPoints, earnedBadges, currentOntology, dataBindings } = useAppStore();
+  const { theme, setTheme, totalPoints, earnedBadges, currentOntology, dataBindings } = useAppStore();
   const route = useRoute();
   const [shareStatus, setShareStatus] = useState<'idle' | 'copying' | 'copied' | 'downloaded'>('idle');
   const [menuOpen, setMenuOpen] = useState(false);
   const menuRef = useRef<HTMLDivElement>(null);
+  const [themeMenuOpen, setThemeMenuOpen] = useState(false);
+  const themeMenuRef = useRef<HTMLDivElement>(null);
 
   const ontologyDisplayName = currentOntology.name || 'Untitled Ontology';
 
@@ -80,6 +82,18 @@ export function Header({ onAboutClick, onHelpClick, onDataSourcesClick, onImport
     document.addEventListener('mousedown', handleClick);
     return () => document.removeEventListener('mousedown', handleClick);
   }, [menuOpen]);
+
+  // Close theme menu when clicking outside
+  useEffect(() => {
+    if (!themeMenuOpen) return;
+    const handleClick = (e: MouseEvent) => {
+      if (themeMenuRef.current && !themeMenuRef.current.contains(e.target as Node)) {
+        setThemeMenuOpen(false);
+      }
+    };
+    document.addEventListener('mousedown', handleClick);
+    return () => document.removeEventListener('mousedown', handleClick);
+  }, [themeMenuOpen]);
 
   const menuAction = (fn: () => void) => () => { setMenuOpen(false); fn(); };
 
@@ -154,9 +168,35 @@ export function Header({ onAboutClick, onHelpClick, onDataSourcesClick, onImport
         <button className="icon-btn" onClick={onDataSourcesClick} data-tooltip="Data Sources" aria-label="Data Sources">
           <Database size={20} />
         </button>
-        <button className="icon-btn" onClick={toggleDarkMode} data-tooltip={darkMode ? 'Light Mode' : 'Dark Mode'} aria-label={darkMode ? 'Light Mode' : 'Dark Mode'}>
-          {darkMode ? <Sun size={20} /> : <Moon size={20} />}
-        </button>
+        <div className="theme-picker" ref={themeMenuRef}>
+          <button
+            className="icon-btn"
+            onClick={() => setThemeMenuOpen((o) => !o)}
+            data-tooltip="Theme"
+            aria-label="Theme"
+            aria-haspopup="menu"
+            aria-expanded={themeMenuOpen}
+          >
+            <Palette size={20} />
+          </button>
+          {themeMenuOpen && (
+            <div className="theme-menu" role="menu">
+              {THEME_OPTIONS.map((opt) => (
+                <button
+                  key={opt.id}
+                  className={`theme-menu-item ${theme === opt.id ? 'active' : ''}`}
+                  onClick={() => { setTheme(opt.id); setThemeMenuOpen(false); }}
+                  role="menuitemradio"
+                  aria-checked={theme === opt.id}
+                >
+                  <span className="theme-swatch" style={{ background: opt.swatch }} />
+                  {opt.label}
+                  {theme === opt.id && <Check size={16} className="theme-check" />}
+                </button>
+              ))}
+            </div>
+          )}
+        </div>
       </div>
 
       {/* Mobile hamburger menu */}
@@ -207,10 +247,19 @@ export function Header({ onAboutClick, onHelpClick, onDataSourcesClick, onImport
             <button className="mobile-menu-item" onClick={menuAction(onDataSourcesClick)}>
               <Database size={18} /> Data Sources
             </button>
-            <button className="mobile-menu-item" onClick={menuAction(toggleDarkMode)}>
-              {darkMode ? <Sun size={18} /> : <Moon size={18} />}
-              {darkMode ? 'Light Mode' : 'Dark Mode'}
-            </button>
+            <div className="mobile-menu-themes">
+              {THEME_OPTIONS.map((opt) => (
+                <button
+                  key={opt.id}
+                  className={`mobile-menu-item ${theme === opt.id ? 'active' : ''}`}
+                  onClick={menuAction(() => setTheme(opt.id))}
+                >
+                  <span className="theme-swatch" style={{ background: opt.swatch }} />
+                  {opt.label}
+                  {theme === opt.id && <Check size={16} className="theme-check" />}
+                </button>
+              ))}
+            </div>
           </div>
         )}
       </div>

--- a/src/components/LearnPage.tsx
+++ b/src/components/LearnPage.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect, useMemo, useRef, useCallback } from 'react';
 import { ArrowLeft, BookOpen, ChevronRight, Sun, Moon, FlaskConical, GraduationCap, Play, X } from 'lucide-react';
 import { AppFooter } from './AppFooter';
-import { useAppStore } from '../store/appStore';
+import { useAppStore, themeClass } from '../store/appStore';
 import { navigate } from '../lib/router';
 import type { Route } from '../lib/router';
 import type { LearnManifest, LearnCourse, LearnArticle } from '../types/learn';
@@ -13,7 +13,7 @@ interface LearnPageProps {
 }
 
 export function LearnPage({ route }: LearnPageProps) {
-  const { darkMode, toggleDarkMode } = useAppStore();
+  const { darkMode, toggleDarkMode, theme } = useAppStore();
   const [manifest, setManifest] = useState<LearnManifest | null>(null);
   const [error, setError] = useState<string | null>(null);
   const pageRef = useRef<HTMLDivElement>(null);
@@ -35,7 +35,7 @@ export function LearnPage({ route }: LearnPageProps) {
 
   if (error) {
     return (
-      <div className={`learn-page ${darkMode ? '' : 'light-theme'}`}>
+      <div className={`learn-page ${themeClass(theme)}`}>
         <div className="learn-error">Failed to load learning content: {error}</div>
       </div>
     );
@@ -43,7 +43,7 @@ export function LearnPage({ route }: LearnPageProps) {
 
   if (!manifest) {
     return (
-      <div className={`learn-page ${darkMode ? '' : 'light-theme'}`}>
+      <div className={`learn-page ${themeClass(theme)}`}>
         <div className="learn-loading">Loading…</div>
       </div>
     );
@@ -72,7 +72,7 @@ export function LearnPage({ route }: LearnPageProps) {
   }
 
   return (
-    <div ref={pageRef} className={`learn-page ${darkMode ? '' : 'light-theme'}`}>
+    <div ref={pageRef} className={`learn-page ${themeClass(theme)}`}>
       <header className="learn-header">
         <button
           className="learn-back-btn"

--- a/src/components/OntologyDesigner.tsx
+++ b/src/components/OntologyDesigner.tsx
@@ -1,7 +1,7 @@
 import { useEffect } from 'react';
 import { ArrowLeft } from 'lucide-react';
 import { useDesignerStore } from '../store/designerStore';
-import { useAppStore } from '../store/appStore';
+import { useAppStore, themeClass } from '../store/appStore';
 import { navigate } from '../lib/router';
 import { EntityForm, RelationshipForm, DesignerPreview, DesignerToolbar, DesignerValidation, TemplatePicker } from './designer';
 import type { Catalogue } from '../types/catalogue';
@@ -13,7 +13,7 @@ interface OntologyDesignerProps {
 
 export function OntologyDesigner({ route }: OntologyDesignerProps) {
   const { ontology, setOntologyName, setOntologyDescription, loadDraft, undo, redo } = useDesignerStore();
-  const darkMode = useAppStore((s) => s.darkMode);
+  const theme = useAppStore((s) => s.theme);
   const isEmpty = ontology.entityTypes.length === 0 && ontology.relationships.length === 0;
 
   // Keyboard shortcuts: Cmd/Ctrl+Z → undo, Cmd/Ctrl+Shift+Z → redo
@@ -53,7 +53,7 @@ export function OntologyDesigner({ route }: OntologyDesignerProps) {
   }, [route.ontologyId, loadDraft]);
 
   return (
-    <div className={`designer-page ${darkMode ? '' : 'light-theme'}`}>
+    <div className={`designer-page ${themeClass(theme)}`}>
       {/* Top bar */}
       <div className="designer-topbar">
         <button className="designer-back-btn" onClick={() => navigate({ page: 'home' })}>

--- a/src/components/OntologyGraph.tsx
+++ b/src/components/OntologyGraph.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useCallback, useMemo, useState } from 'react';
+import { useEffect, useRef, useCallback, useState } from 'react';
 import cytoscape from 'cytoscape';
 import fcose from 'cytoscape-fcose';
 import type { Core, EventObject, LayoutOptions } from 'cytoscape';
@@ -12,6 +12,24 @@ declare global {
   interface Window {
     __ONTOLOGY_PREVIEW_CY__?: Core;
   }
+}
+
+type GraphColors = { nodeText: string; edgeColor: string; edgeText: string };
+
+// Read graph colors from the active theme's CSS custom properties, falling
+// back to the dark/light defaults when the variables can't be resolved yet.
+function readGraphColors(darkMode: boolean, el?: HTMLElement | null): GraphColors {
+  const fallback: GraphColors = darkMode
+    ? { nodeText: '#B3B3B3', edgeColor: '#505050', edgeText: '#808080' }
+    : { nodeText: '#2A2A2A', edgeColor: '#888888', edgeText: '#555555' };
+  const source = el ?? (typeof document !== 'undefined' ? document.querySelector<HTMLElement>('.app-container') : null);
+  if (!source) return fallback;
+  const cs = getComputedStyle(source);
+  return {
+    nodeText: cs.getPropertyValue('--graph-node-text').trim() || fallback.nodeText,
+    edgeColor: cs.getPropertyValue('--graph-edge-color').trim() || fallback.edgeColor,
+    edgeText: cs.getPropertyValue('--graph-edge-text').trim() || fallback.edgeText,
+  };
 }
 
 export function OntologyGraph() {
@@ -45,7 +63,8 @@ export function OntologyGraph() {
     activeQuest,
     currentStepIndex,
     advanceQuestStep,
-    darkMode
+    darkMode,
+    theme
   } = useAppStore();
 
   // Use refs for quest state to avoid re-creating the graph when quest changes
@@ -60,11 +79,12 @@ export function OntologyGraph() {
     advanceQuestStepRef.current = advanceQuestStep;
   }, [activeQuest, currentStepIndex, advanceQuestStep]);
   
-  // Theme-aware colors - memoized to prevent unnecessary re-renders
-  const themeColors = useMemo(() => darkMode 
-    ? { nodeText: '#B3B3B3', edgeColor: '#505050', edgeText: '#808080' }
-    : { nodeText: '#2A2A2A', edgeColor: '#888888', edgeText: '#555555' },
-  [darkMode]);
+  // Theme-aware colors, sourced from the active theme's CSS variables so each
+  // theme (including the derived ones) renders with its own graph palette.
+  const [themeColors, setThemeColors] = useState<GraphColors>(() => readGraphColors(darkMode));
+  useEffect(() => {
+    setThemeColors(readGraphColors(darkMode, containerRef.current));
+  }, [theme, darkMode]);
 
   // Initial theme colors for graph creation
   const initialThemeColors = useRef(themeColors);
@@ -505,7 +525,8 @@ export function OntologyGraph() {
     const cy = getCy();
     if (!cy) return;
     try {
-      const bg = darkMode ? '#1E1E1E' : '#F5F5F5';
+      const graphCs = containerRef.current ? getComputedStyle(containerRef.current) : null;
+      const bg = (graphCs && graphCs.getPropertyValue('--graph-bg').trim()) || (darkMode ? '#1E1E1E' : '#F5F5F5');
       const pngData = cy.png({ scale: 2, full: true, bg });
       const link = document.createElement('a');
       link.href = pngData;

--- a/src/components/designer/DesignerPreview.tsx
+++ b/src/components/designer/DesignerPreview.tsx
@@ -3,7 +3,7 @@ import cytoscape from 'cytoscape';
 import fcose from 'cytoscape-fcose';
 import type { Core } from 'cytoscape';
 import { useDesignerStore } from '../../store/designerStore';
-import { useAppStore } from '../../store/appStore';
+import { useAppStore, type ThemeId } from '../../store/appStore';
 import { serializeToRDF } from '../../lib/rdf/serializer';
 import { parseRDF } from '../../lib/rdf/parser';
 import { highlightRdf, RDF_HIGHLIGHT_DARK, RDF_HIGHLIGHT_LIGHT } from '../../lib/rdf/highlighter';
@@ -13,7 +13,7 @@ cytoscape.use(fcose);
 export function DesignerPreview() {
   const [activeTab, setActiveTab] = useState<'graph' | 'rdf'>('graph');
   const { ontology, selectEntity, selectRelationship } = useDesignerStore();
-  const darkMode = useAppStore((s) => s.darkMode);
+  const theme = useAppStore((s) => s.theme);
 
   return (
     <div className="designer-preview">
@@ -35,7 +35,7 @@ export function DesignerPreview() {
       {activeTab === 'graph' ? (
         <GraphPreview
           ontology={ontology}
-          darkMode={darkMode}
+          theme={theme}
           onSelectEntity={selectEntity}
           onSelectRelationship={selectRelationship}
         />
@@ -50,22 +50,14 @@ export function DesignerPreview() {
 
 interface GraphPreviewProps {
   ontology: { entityTypes: { id: string; name: string; icon: string; color: string }[]; relationships: { id: string; name: string; from: string; to: string; cardinality: string }[] };
-  darkMode: boolean;
+  theme: ThemeId;
   onSelectEntity: (id: string | null) => void;
   onSelectRelationship: (id: string | null) => void;
 }
 
-function GraphPreview({ ontology, darkMode, onSelectEntity, onSelectRelationship }: GraphPreviewProps) {
+function GraphPreview({ ontology, theme, onSelectEntity, onSelectRelationship }: GraphPreviewProps) {
   const containerRef = useRef<HTMLDivElement>(null);
   const cyRef = useRef<Core | null>(null);
-
-  const themeColors = useMemo(
-    () =>
-      darkMode
-        ? { nodeText: '#B3B3B3', edgeColor: '#505050', edgeText: '#808080' }
-        : { nodeText: '#2A2A2A', edgeColor: '#888888', edgeText: '#555555' },
-    [darkMode],
-  );
 
   const buildElements = useCallback(() => {
     const nodes = ontology.entityTypes.map((e) => ({
@@ -77,9 +69,16 @@ function GraphPreview({ ontology, darkMode, onSelectEntity, onSelectRelationship
     return [...nodes, ...edges];
   }, [ontology]);
 
-  // Create graph once; update elements incrementally
+  // Create graph; recreate on theme change. Graph colors are read from the
+  // active theme's CSS custom properties so each theme uses its own palette.
   useEffect(() => {
     if (!containerRef.current) return;
+    const cssVars = getComputedStyle(containerRef.current);
+    const themeColors = {
+      nodeText: cssVars.getPropertyValue('--graph-node-text').trim() || '#B3B3B3',
+      edgeColor: cssVars.getPropertyValue('--graph-edge-color').trim() || '#505050',
+      edgeText: cssVars.getPropertyValue('--graph-edge-text').trim() || '#808080',
+    };
     const cy = cytoscape({
       container: containerRef.current,
       elements: buildElements(),
@@ -144,7 +143,7 @@ function GraphPreview({ ontology, darkMode, onSelectEntity, onSelectRelationship
     cyRef.current = cy;
     return () => { cy.destroy(); cyRef.current = null; };
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [themeColors]); // Only recreate on theme change
+  }, [theme]); // Recreate on theme change to re-read CSS colors
 
   // Incrementally sync nodes & edges without full relayout
   useEffect(() => {

--- a/src/store/appStore.ts
+++ b/src/store/appStore.ts
@@ -5,18 +5,56 @@ import type { Ontology, DataBinding } from '../data/ontology';
 import { cosmicCoffeeOntology, sampleBindings } from '../data/ontology';
 import { generateQuestsForOntology } from '../data/questGenerator';
 
-function getInitialDarkMode(): boolean {
-  if (typeof window === 'undefined' || !('localStorage' in window)) {
-    return true;
-  }
-  try {
-    const stored = window.localStorage.getItem('darkMode');
-    if (stored === 'false') return false;
-    return true;
-  } catch {
-    return true;
+export type ThemeId = 'dark' | 'light' | 'aurora' | 'crimson';
+
+export const THEME_OPTIONS: { id: ThemeId; label: string; swatch: string }[] = [
+  { id: 'dark', label: 'Dark', swatch: '#1B1B1B' },
+  { id: 'light', label: 'Light', swatch: '#F5F5F5' },
+  { id: 'aurora', label: 'Aurora', swatch: '#2AAA92' },
+  { id: 'crimson', label: 'Crimson', swatch: '#D6002A' },
+];
+
+const DARK_BASED_THEMES: ThemeId[] = ['dark', 'aurora'];
+
+/** Whether a theme uses the dark base palette (drives graph/RDF rendering). */
+export function isDarkTheme(theme: ThemeId): boolean {
+  return DARK_BASED_THEMES.includes(theme);
+}
+
+/** CSS class(es) applied to a themed root element. */
+export function themeClass(theme: ThemeId): string {
+  switch (theme) {
+    case 'light':
+      return 'light-theme';
+    case 'aurora':
+      return 'theme-aurora';
+    case 'crimson':
+      return 'light-theme theme-crimson';
+    default:
+      return '';
   }
 }
+
+function getInitialTheme(): ThemeId {
+  if (typeof window === 'undefined' || !('localStorage' in window)) {
+    return 'dark';
+  }
+  try {
+    const stored = window.localStorage.getItem('theme');
+    if (stored && THEME_OPTIONS.some((t) => t.id === stored)) {
+      return stored as ThemeId;
+    }
+    // Migrate the legacy light/dark flag
+    if (window.localStorage.getItem('darkMode') === 'false') {
+      return 'light';
+    }
+    return 'dark';
+  } catch {
+    return 'dark';
+  }
+}
+
+const initialTheme = getInitialTheme();
 
 interface AppState {
   // Ontology State
@@ -29,6 +67,7 @@ interface AppState {
   highlightedEntities: string[];
   highlightedRelationships: string[];
   showDataBindings: boolean;
+  theme: ThemeId;
   darkMode: boolean;
   
   // Quest State
@@ -55,6 +94,7 @@ interface AppState {
   setHighlightedRelationships: (ids: string[]) => void;
   setHighlights: (entityIds: string[], relIds: string[]) => void;
   toggleDataBindings: () => void;
+  setTheme: (theme: ThemeId) => void;
   toggleDarkMode: () => void;
   
   // Quest Actions
@@ -80,7 +120,8 @@ export const useAppStore = create<AppState>((set, get) => ({
   highlightedEntities: [],
   highlightedRelationships: [],
   showDataBindings: false,
-  darkMode: getInitialDarkMode(),
+  theme: initialTheme,
+  darkMode: isDarkTheme(initialTheme),
   
   // Initial Quest State - use default quests for Fourth Coffee
   availableQuests: defaultQuests,
@@ -147,15 +188,18 @@ export const useAppStore = create<AppState>((set, get) => ({
   setHighlights: (entityIds, relIds) => set({ highlightedEntities: entityIds, highlightedRelationships: relIds }),
   
   toggleDataBindings: () => set((state) => ({ showDataBindings: !state.showDataBindings })),
-  toggleDarkMode: () => set((state) => {
-    const next = !state.darkMode;
+  setTheme: (theme) => {
     try {
-      localStorage.setItem('darkMode', String(next));
+      localStorage.setItem('theme', theme);
     } catch {
       // Ignore persistence errors; still update in-memory state
     }
-    return { darkMode: next };
-  }),
+    set({ theme, darkMode: isDarkTheme(theme) });
+  },
+  toggleDarkMode: () => {
+    const next: ThemeId = isDarkTheme(get().theme) ? 'light' : 'dark';
+    get().setTheme(next);
+  },
   
   // Quest Actions
   startQuest: (questId) => {

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -100,22 +100,22 @@
   --info: #2AAA92;
   --ms-cyan: #6AD6F9;
 
-  --bg-primary: #0C1A18;
-  --bg-secondary: #11302C;
-  --bg-tertiary: #18443E;
-  --bg-elevated: #143832;
+  --bg-primary: #0E2B27;
+  --bg-secondary: #14352F;
+  --bg-tertiary: #1C463E;
+  --bg-elevated: #173E37;
   --text-primary: #EAFBF6;
-  --text-secondary: #9DC9BF;
-  --text-tertiary: #6E978E;
-  --border-color: #1E544C;
-  --border-subtle: #173F39;
+  --text-secondary: #A6D2C8;
+  --text-tertiary: #779E95;
+  --border-color: #265C53;
+  --border-subtle: #1C4640;
 
   --shadow-glow: 0 0 20px rgba(42, 170, 146, 0.35);
 
-  --graph-bg: #0E211E;
-  --graph-node-text: #9DC9BF;
-  --graph-edge-color: #2E5A52;
-  --graph-edge-text: #6E978E;
+  --graph-bg: #0F2D28;
+  --graph-node-text: #C2E6DC;
+  --graph-edge-color: #4F8C7F;
+  --graph-edge-text: #8FBDB2;
 
   --chess-square-dark: rgba(8, 40, 36, 0.85);
   --chess-square-light: rgba(16, 64, 58, 0.6);

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -147,8 +147,10 @@
   --graph-edge-color: #ADB5BD;
   --graph-edge-text: #6C757D;
 
-  --chess-square-dark: rgba(214, 0, 42, 0.06);
-  --chess-square-light: rgba(214, 0, 42, 0.03);
+  /* Opaque light base so the canvas reads light (the dark body must not show
+     through); faint crimson squares keep the branded checker pattern. */
+  --chess-square-dark: rgba(214, 0, 42, 0.07);
+  --chess-square-light: #FBF7F8;
   --about-link-color: #A8001F;
   --about-link-hover-color: #D6002A;
 }

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -92,6 +92,145 @@
   --about-link-hover-color: #003a63;
 }
 
+/* Aurora theme — deep teal base with mint accents (dark) */
+.theme-aurora {
+  --ms-blue: #2AAA92;
+  --ms-blue-dark: #1F8D78;
+  --ms-blue-light: #3FD0B4;
+  --info: #2AAA92;
+  --ms-cyan: #6AD6F9;
+
+  --bg-primary: #0C1A18;
+  --bg-secondary: #11302C;
+  --bg-tertiary: #18443E;
+  --bg-elevated: #143832;
+  --text-primary: #EAFBF6;
+  --text-secondary: #9DC9BF;
+  --text-tertiary: #6E978E;
+  --border-color: #1E544C;
+  --border-subtle: #173F39;
+
+  --shadow-glow: 0 0 20px rgba(42, 170, 146, 0.35);
+
+  --graph-bg: #0E211E;
+  --graph-node-text: #9DC9BF;
+  --graph-edge-color: #2E5A52;
+  --graph-edge-text: #6E978E;
+
+  --chess-square-dark: rgba(8, 40, 36, 0.85);
+  --chess-square-light: rgba(16, 64, 58, 0.6);
+  --about-link-color: #6DE9BB;
+  --about-link-hover-color: #ABE88E;
+}
+
+/* Crimson theme — clean light surfaces with a crimson accent (light) */
+.theme-crimson {
+  --ms-blue: #D6002A;
+  --ms-blue-dark: #A8001F;
+  --ms-blue-light: #E63956;
+  --info: #D6002A;
+
+  --bg-primary: #F8F9FA;
+  --bg-secondary: #FFFFFF;
+  --bg-tertiary: #EEF0F2;
+  --bg-elevated: #FFFFFF;
+  --text-primary: #1B1F24;
+  --text-secondary: #495057;
+  --text-tertiary: #6C757D;
+  --border-color: #D6DAE0;
+  --border-subtle: #E3E6EA;
+
+  --shadow-glow: 0 0 20px rgba(214, 0, 42, 0.22);
+
+  --graph-bg: #FFFFFF;
+  --graph-node-text: #1B1F24;
+  --graph-edge-color: #ADB5BD;
+  --graph-edge-text: #6C757D;
+
+  --chess-square-dark: rgba(214, 0, 42, 0.06);
+  --chess-square-light: rgba(214, 0, 42, 0.03);
+  --about-link-color: #A8001F;
+  --about-link-hover-color: #D6002A;
+}
+
+/* Theme picker (header) */
+.theme-picker {
+  position: relative;
+  display: inline-flex;
+}
+
+.theme-menu {
+  position: absolute;
+  top: calc(100% + 8px);
+  right: 0;
+  min-width: 172px;
+  background: var(--bg-elevated);
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-md);
+  box-shadow: var(--shadow-lg);
+  padding: 6px;
+  z-index: 1000;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.theme-menu-item {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  width: 100%;
+  padding: 8px 10px;
+  border: none;
+  background: none;
+  color: var(--text-primary);
+  font: inherit;
+  font-size: 13px;
+  cursor: pointer;
+  border-radius: var(--radius-sm);
+  text-align: left;
+  transition: background var(--transition-fast);
+}
+
+.theme-menu-item:hover {
+  background: var(--bg-tertiary);
+}
+
+.theme-menu-item.active {
+  color: var(--ms-blue);
+  font-weight: 600;
+}
+
+.theme-menu-item .theme-check {
+  margin-left: auto;
+}
+
+.theme-swatch {
+  width: 14px;
+  height: 14px;
+  border-radius: 4px;
+  border: 1px solid var(--border-color);
+  flex-shrink: 0;
+}
+
+.mobile-menu-themes {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  border-top: 1px solid var(--border-subtle);
+  margin-top: 4px;
+  padding-top: 4px;
+}
+
+.mobile-menu-themes .theme-check {
+  margin-left: auto;
+}
+
+.mobile-menu-item.active {
+  color: var(--ms-blue);
+  font-weight: 600;
+}
+
 .about-link {
   color: var(--about-link-color);
   text-decoration: underline;


### PR DESCRIPTION
## Summary

Adds a small multi-theme system on top of the existing Dark/Light modes, makes
the graph views theme-aware, and ships docs + a skill for authoring new themes.

Four themes are available from a new header theme picker:

| Theme | Base | Look |
| --- | --- | --- |
| Dark | dark | unchanged default |
| Light | light | unchanged |
| Aurora | dark | deep-teal surfaces, mint accents |
| Crimson | light | clean light surfaces, crimson accent |

The selected theme persists across sessions (`localStorage['theme']`) and themes
every surface: the main graph, the designer preview, and the learn pages.

## What changed

- **Theme system** — `ThemeId` + `THEME_OPTIONS` in the store drive a header
  theme picker; `themeClass()` maps each theme to CSS-variable token blocks in
  `app.css`. A derived `darkMode` flag keeps the existing light/dark behavior.
- **Theme-aware graphs** — `OntologyGraph` and the designer's `GraphPreview` now
  read graph colors (`--graph-bg`, `--graph-node-text`, `--graph-edge-color`,
  `--graph-edge-text`) from CSS variables at runtime instead of hardcoding two
  dark/light states, so every theme gets correct, legible contrast.
- **Contrast fixes** — Aurora surfaces were lightened from near-black to a deep
  teal; the Crimson graph canvas now uses an opaque light base so the dark page
  body can't bleed through and labels stay readable.
- **Docs + skill** — `docs/theme-authoring-guide.md` (token contract, step-by-step
  instructions, gotchas, worked example) and a `theme-authoring` skill, linked
  from the README documentation table.

## Testing

- `npx tsc --noEmit` — clean.
- `npm run build` — passes.
- Manual verification across all four themes: main graph, designer preview, and
  learn pages render with legible node/edge labels; theme selection persists on
  reload; Dark and Light are visually unchanged from before.

## Notes for reviewers

- Dark and Light are byte-for-byte equivalent in behavior: their CSS `--graph-*`
  values match the previously hardcoded literals, so there is no regression.
- No component or graph-rendering edits are required to add future themes — see
  the authoring guide.
