### PR TITLE
fix(themes): meet WCAG 2.1 AA contrast across all themes + CI gate

### DIFF
--- a/.github/skills/theme-authoring/SKILL.md
+++ b/.github/skills/theme-authoring/SKILL.md
@@ -50,8 +50,13 @@ Make all edits in [`src/store/appStore.ts`](../../../src/store/appStore.ts) and
   the dark body bleed through → dark canvas + unreadable labels. Use an opaque
   light color (e.g. `#FBF7F8`), not `rgba(..., 0.03)`. (Guide → Gotcha 1.)
 - **Graph colors are CSS-driven.** Define `--graph-bg`, `--graph-node-text`,
-  `--graph-edge-color`, `--graph-edge-text` in the block; the graph and designer
-  read them at runtime. No `.tsx` edits. Tune for contrast against `--graph-bg`.
+  `--graph-edge-color`, `--graph-edge-text`, `--graph-edge-label-bg` in the
+  block; the graph and designer read them at runtime. No `.tsx` edits.
+- **Meet WCAG 2.1 AA contrast.** Text and labels need 4.5:1; graph edge lines and
+  other non-text need 3:1. Set `--on-accent` (label color on accent fills) to a
+  **dark** value for a **light** accent (white fails on Aurora's mint) and white
+  for a dark accent. Edge text must clear 4.5:1 against `--graph-edge-label-bg`.
+  `npm run test:a11y` enforces this for every theme. (Guide → Accessibility.)
 - **Register dark themes** in `DARK_BASED_THEMES` so `darkMode` is correct
   (graph fallback, label backplate, PNG export bg).
 - **Don't introduce brand names** in ids, labels, comments, or commits. Use
@@ -66,6 +71,7 @@ If any example data, docs, or sample instances need person names, use the
 
 ```bash
 npm run dev          # switch to the theme in the header; check graph, designer, learn pages
+npm run test:a11y    # WCAG 2.1 AA contrast for every theme (also a CI gate)
 npx tsc --noEmit     # the ThemeId union change is type-checked here
 npm run build        # full build
 ```
@@ -80,4 +86,5 @@ If `npm run build` only changed `public/learn.json` (a timestamp), revert it:
 - Main graph, designer preview, and learn pages are legible in the new theme;
   the graph canvas backdrop matches the theme (Gotcha 1 satisfied).
 - Dark, Light, Aurora, Crimson unchanged.
+- `npm run test:a11y` passes (WCAG 2.1 AA contrast for the new theme).
 - `tsc --noEmit` and `npm run build` pass; no brand references introduced.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,9 @@ jobs:
       - name: Type check
         run: npx tsc -b
 
+      - name: Accessibility — WCAG 2.1 AA contrast
+        run: npm run test:a11y
+
       - name: Run tests
         run: npm test
 

--- a/TODO.md
+++ b/TODO.md
@@ -252,6 +252,9 @@ These enhance the overall experience for a community learning resource.
 - [ ] Useful for reviewing community PRs or comparing versions
 
 ### 5.3 Accessibility & responsive design
+- [x] WCAG 2.1 AA color contrast: audited all four themes, fixed failing text and
+      graph tokens, added `--on-accent` / `--graph-edge-label-bg`, and wired an
+      automated contrast gate (`npm run test:a11y`) into CI
 - [ ] Audit and fix keyboard navigation across all modals and panels
 - [ ] Add ARIA labels to the graph visualization
 - [ ] Ensure the app is usable on tablet-sized screens (responsive breakpoints)

--- a/docs/theme-authoring-guide.md
+++ b/docs/theme-authoring-guide.md
@@ -74,11 +74,12 @@ over it).
 | Group | Tokens | Notes |
 | --- | --- | --- |
 | Accent | `--ms-blue`, `--ms-blue-dark`, `--ms-blue-light`, `--info` | Primary accent used across buttons, links, highlights. Override these to re-brand the accent color. |
+| Accent foreground | `--on-accent` | Text/icon color placed **on** an accent-colored fill (e.g. `.btn-primary`). Must clear 4.5:1 against `--ms-blue`. White suits a dark accent; a **light** accent (e.g. Aurora's mint) needs a **dark** value. Inherited from `:root` (white) unless overridden. |
 | Surfaces | `--bg-primary`, `--bg-secondary`, `--bg-tertiary`, `--bg-elevated` | Page and panel backgrounds, lightest → most elevated. |
 | Text | `--text-primary`, `--text-secondary`, `--text-tertiary` | Foreground text, primary → muted. |
 | Borders | `--border-color`, `--border-subtle` | Panel/control borders. |
 | Shadow | `--shadow-glow` | Accent glow; tint it to match the accent. |
-| Graph | `--graph-bg`, `--graph-node-text`, `--graph-edge-color`, `--graph-edge-text` | Read at runtime by the graph + designer preview. **Tune these for contrast against `--graph-bg`.** |
+| Graph | `--graph-bg`, `--graph-node-text`, `--graph-edge-color`, `--graph-edge-text`, `--graph-edge-label-bg` | Read at runtime by the graph + designer preview. `--graph-edge-label-bg` is the **opaque** chip behind edge labels; edge text must clear 4.5:1 against it. **Tune all of these for contrast** — see [Accessibility](#accessibility-wcag-21-aa-contrast). |
 | Canvas checker | `--chess-square-dark`, `--chess-square-light` | The graph canvas backdrop pattern. `--chess-square-light` is the **solid base** — see [Gotcha 1](#gotcha-1-the-body-stays-dark). |
 | About links | `--about-link-color`, `--about-link-hover-color` | Links on the About screen. |
 
@@ -146,10 +147,11 @@ light) and retune. Place it after the existing theme blocks.
 ```css
 /* Indigo theme — deep indigo base with violet accents (dark) */
 .theme-indigo {
-  --ms-blue: #6366F1;
-  --ms-blue-dark: #4F46E5;
-  --ms-blue-light: #818CF8;
-  --info: #6366F1;
+  --ms-blue: #4F46E5;
+  --ms-blue-dark: #4338CA;
+  --ms-blue-light: #6366F1;
+  --info: #4F46E5;
+  --on-accent: #FFFFFF;       /* white clears 4.5:1 on this indigo accent */
 
   --bg-primary: #15172B;
   --bg-secondary: #1C1F3A;
@@ -165,8 +167,9 @@ light) and retune. Place it after the existing theme blocks.
 
   --graph-bg: #14162A;
   --graph-node-text: #CDD2FF;
-  --graph-edge-color: #5A5FA0;
+  --graph-edge-color: #686DAE;
   --graph-edge-text: #9AA0D6;
+  --graph-edge-label-bg: #181A2E;   /* opaque chip behind edge labels */
 
   --chess-square-dark: rgba(40, 44, 90, 0.85);
   --chess-square-light: rgba(30, 33, 70, 0.65);
@@ -227,10 +230,12 @@ already dark.
 ### Gotcha 2: graph colors come from CSS, not props
 
 `OntologyGraph` and the designer's `GraphPreview` read `--graph-node-text`,
-`--graph-edge-color`, and `--graph-edge-text` from `getComputedStyle` and
-re-read them when the active `theme` changes. So **defining the `--graph-*`
-tokens in your theme block is all you need** — no component or TypeScript edits.
-Tune them for contrast against your `--graph-bg`.
+`--graph-edge-color`, `--graph-edge-text`, and `--graph-edge-label-bg` from
+`getComputedStyle` and re-read them when the active `theme` changes. So
+**defining the `--graph-*` tokens in your theme block is all you need** — no
+component or TypeScript edits. Tune them for contrast against your `--graph-bg`
+(and edge text against `--graph-edge-label-bg`); see
+[Accessibility](#accessibility-wcag-21-aa-contrast).
 
 ### Gotcha 3: register dark-based themes in `DARK_BASED_THEMES`
 
@@ -244,6 +249,44 @@ will briefly fall back to light defaults and labels can get a light backplate.
 Returning `'light-theme theme-<id>'` from `themeClass` lets your block inherit
 every light token and override only what's distinctive. Returning a single class
 means you must re-specify the full token set or inherit Dark defaults by mistake.
+
+---
+
+## Accessibility (WCAG 2.1 AA contrast)
+
+Every theme must meet **WCAG 2.1 Level AA** contrast — the standard Microsoft's
+Accessibility Insights verifies. A deterministic test enforces it for **all**
+themes, so a new theme or a token tweak can't silently ship a failing color:
+
+- **Body text** (`--text-primary`, `--text-secondary`) and **muted text**
+  (`--text-tertiary`) need **4.5:1** against the surfaces they sit on
+  (`--bg-primary`, `--bg-secondary`, `--bg-elevated`).
+- **Accent button labels** (`--on-accent`) need **4.5:1** against `--ms-blue`.
+- **Graph labels** need **4.5:1** — node text against `--graph-bg`, edge text
+  against the opaque `--graph-edge-label-bg` chip.
+- **Graph edge lines** (`--graph-edge-color`) are graphical objects and need
+  **3:1** against `--graph-bg` (SC 1.4.11 Non-text Contrast).
+
+Thresholds are floors — `4.49:1` fails.
+
+### Run it
+
+```bash
+npm run test:a11y
+```
+
+The suite ([`src/a11y/themeContrast.test.ts`](../src/a11y/themeContrast.test.ts))
+parses [`src/styles/app.css`](../src/styles/app.css), resolves each theme's
+tokens, and asserts every text/non-text pair clears its threshold. It runs in CI
+(the **“Accessibility — WCAG 2.1 AA contrast”** step) and inside `npm test`, so a
+regression fails the build. A failure prints the exact ratio and both tokens, e.g.
+`--text-tertiary (#808080) on --bg-secondary (#2D2D2D) = 3.49:1, needs >= 4.5:1`.
+Nudge the failing token lighter/darker until it clears, then re-run.
+
+> **Light accents need dark label text.** White on a light accent fails AA
+> (Aurora's mint `#2AAA92` + white = 2.89:1). That's what `--on-accent` is for:
+> set it dark for a light accent (Aurora uses `#08221D`), white for a dark
+> accent. Accent-filled controls use `color: var(--on-accent)`.
 
 ---
 
@@ -264,10 +307,12 @@ Check, in the new theme:
       selection.
 - [ ] **Persistence**: reload the page — the theme is remembered.
 - [ ] **No regressions**: Dark, Light, Aurora, and Crimson still look correct.
+- [ ] **Contrast**: `npm run test:a11y` is green for the new theme (WCAG 2.1 AA).
 
 Then:
 
 ```bash
+npm run test:a11y    # WCAG 2.1 AA contrast for every theme (also runs in CI)
 npx tsc --noEmit     # type-check (the ThemeId union change is covered here)
 npm run build        # full production build
 ```

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "secrets:scan": "gitleaks detect --source . --redact --config .gitleaks.toml",
     "test": "vitest run",
     "test:watch": "vitest",
+    "test:a11y": "vitest run src/a11y",
     "validate": "tsx scripts/validate-rdf.ts",
     "preview:ontology:list": "tsx scripts/list-changed-catalogue-entries.ts",
     "preview:ontology:render": "tsx scripts/render-ontology-previews.ts",

--- a/src/a11y/contrast.ts
+++ b/src/a11y/contrast.ts
@@ -1,0 +1,115 @@
+// WCAG 2.1 color-contrast utilities (Success Criteria 1.4.3 and 1.4.11).
+//
+// Pure and dependency-free so it can run in the unit-test suite and be reused
+// by tooling. Implements the relative-luminance and contrast-ratio formulas
+// exactly as defined by WCAG, including the rule that the published thresholds
+// are floors that must not be rounded (4.499:1 does NOT meet 4.5:1).
+
+export interface RGB {
+  /** 0–255 */ r: number;
+  /** 0–255 */ g: number;
+  /** 0–255 */ b: number;
+}
+
+export interface RGBA extends RGB {
+  /** 0–1 */ a: number;
+}
+
+/** SC 1.4.3 — normal text. */
+export const AA_NORMAL_TEXT = 4.5;
+/** SC 1.4.3 — large text (>= 24px, or >= 18.66px bold). */
+export const AA_LARGE_TEXT = 3;
+/** SC 1.4.11 — UI components and graphical objects. */
+export const AA_NON_TEXT = 3;
+
+const HEX3 = /^#([0-9a-f])([0-9a-f])([0-9a-f])$/i;
+const HEX6 = /^#([0-9a-f]{2})([0-9a-f]{2})([0-9a-f]{2})$/i;
+const HEX8 = /^#([0-9a-f]{2})([0-9a-f]{2})([0-9a-f]{2})([0-9a-f]{2})$/i;
+const RGB_FN =
+  /^rgba?\(\s*([\d.]+)\s*[, ]\s*([\d.]+)\s*[, ]\s*([\d.]+)\s*(?:[,/]\s*([\d.]+%?)\s*)?\)$/i;
+
+/** Parse a CSS hex (`#rgb`, `#rrggbb`, `#rrggbbaa`) or rgb()/rgba() color. */
+export function parseColor(input: string): RGBA {
+  const s = input.trim();
+
+  let m = HEX8.exec(s);
+  if (m) {
+    return {
+      r: parseInt(m[1], 16),
+      g: parseInt(m[2], 16),
+      b: parseInt(m[3], 16),
+      a: parseInt(m[4], 16) / 255,
+    };
+  }
+  m = HEX6.exec(s);
+  if (m) {
+    return { r: parseInt(m[1], 16), g: parseInt(m[2], 16), b: parseInt(m[3], 16), a: 1 };
+  }
+  m = HEX3.exec(s);
+  if (m) {
+    return {
+      r: parseInt(m[1] + m[1], 16),
+      g: parseInt(m[2] + m[2], 16),
+      b: parseInt(m[3] + m[3], 16),
+      a: 1,
+    };
+  }
+  m = RGB_FN.exec(s);
+  if (m) {
+    const rawAlpha = m[4];
+    const a =
+      rawAlpha == null ? 1 : rawAlpha.endsWith('%') ? parseFloat(rawAlpha) / 100 : parseFloat(rawAlpha);
+    return { r: Number(m[1]), g: Number(m[2]), b: Number(m[3]), a };
+  }
+
+  throw new Error(`Unsupported color format: "${input}"`);
+}
+
+/** Flatten a (possibly translucent) foreground over an opaque background. */
+export function composite(fg: RGBA, bg: RGB): RGB {
+  const a = fg.a;
+  return {
+    r: Math.round(fg.r * a + bg.r * (1 - a)),
+    g: Math.round(fg.g * a + bg.g * (1 - a)),
+    b: Math.round(fg.b * a + bg.b * (1 - a)),
+  };
+}
+
+function channelLuminance(channel8bit: number): number {
+  const c = channel8bit / 255;
+  return c <= 0.03928 ? c / 12.92 : Math.pow((c + 0.055) / 1.055, 2.4);
+}
+
+/** WCAG relative luminance of an opaque color. */
+export function relativeLuminance(rgb: RGB): number {
+  return (
+    0.2126 * channelLuminance(rgb.r) +
+    0.7152 * channelLuminance(rgb.g) +
+    0.0722 * channelLuminance(rgb.b)
+  );
+}
+
+/**
+ * WCAG contrast ratio between a foreground and background color. A translucent
+ * foreground is composited over the (opaque) background first. The background
+ * must be opaque, because contrast against an unknown surface is undefined.
+ */
+export function contrastRatio(foreground: string, background: string): number {
+  const bg = parseColor(background);
+  if (bg.a < 1) {
+    throw new Error(`Background color must be opaque to measure contrast: "${background}"`);
+  }
+  const fg = parseColor(foreground);
+  const fgOpaque: RGB = fg.a < 1 ? composite(fg, bg) : fg;
+
+  const l1 = relativeLuminance(fgOpaque);
+  const l2 = relativeLuminance(bg);
+  const lighter = Math.max(l1, l2);
+  const darker = Math.min(l1, l2);
+  return (lighter + 0.05) / (darker + 0.05);
+}
+
+/** True when the pair meets `minimum`. Thresholds are floors (not rounded). */
+export function meetsContrast(foreground: string, background: string, minimum: number): boolean {
+  return contrastRatio(foreground, background) >= minimum;
+}

--- a/src/a11y/themeContrast.test.ts
+++ b/src/a11y/themeContrast.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect } from 'vitest';
+import { contrastRatio, AA_NORMAL_TEXT, AA_NON_TEXT } from './contrast';
+import { THEMES, getThemeTokens } from './themeTokens';
+
+// Microsoft's accessibility bar is WCAG 2.1 Level AA. This suite enforces the
+// contrast contract for every theme so a new theme — or a tweak to an existing
+// one — cannot ship a combination that fails to meet:
+//   * SC 1.4.3 Contrast (Minimum): 4.5:1 for normal text.
+//   * SC 1.4.11 Non-text Contrast: 3:1 for graphical objects (graph edges).
+//
+// Foreground/background are CSS custom-property names resolved from app.css.
+
+type Kind = 'text' | 'non-text';
+
+interface Pair {
+  name: string;
+  fg: string;
+  bg: string;
+  kind: Kind;
+}
+
+const PAIRS: Pair[] = [
+  { name: 'primary text on app background', fg: '--text-primary', bg: '--bg-primary', kind: 'text' },
+  { name: 'primary text on panel', fg: '--text-primary', bg: '--bg-secondary', kind: 'text' },
+  { name: 'secondary text on app background', fg: '--text-secondary', bg: '--bg-primary', kind: 'text' },
+  { name: 'secondary text on panel', fg: '--text-secondary', bg: '--bg-secondary', kind: 'text' },
+  { name: 'secondary text on elevated surface', fg: '--text-secondary', bg: '--bg-elevated', kind: 'text' },
+  { name: 'muted text on app background', fg: '--text-tertiary', bg: '--bg-primary', kind: 'text' },
+  { name: 'muted text on panel', fg: '--text-tertiary', bg: '--bg-secondary', kind: 'text' },
+  { name: 'about link on app background', fg: '--about-link-color', bg: '--bg-primary', kind: 'text' },
+  { name: 'button label on accent', fg: '--on-accent', bg: '--ms-blue', kind: 'text' },
+  { name: 'graph node label on canvas', fg: '--graph-node-text', bg: '--graph-bg', kind: 'text' },
+  { name: 'graph edge label on chip', fg: '--graph-edge-text', bg: '--graph-edge-label-bg', kind: 'text' },
+  { name: 'graph edge line on canvas', fg: '--graph-edge-color', bg: '--graph-bg', kind: 'non-text' },
+];
+
+const minimumFor = (kind: Kind): number => (kind === 'text' ? AA_NORMAL_TEXT : AA_NON_TEXT);
+
+describe('WCAG 2.1 AA theme contrast (SC 1.4.3 / 1.4.11)', () => {
+  for (const theme of THEMES) {
+    const tokens = getThemeTokens(theme);
+
+    describe(theme, () => {
+      for (const pair of PAIRS) {
+        const minimum = minimumFor(pair.kind);
+        it(`${pair.name} meets ${minimum}:1`, () => {
+          const fg = tokens[pair.fg];
+          const bg = tokens[pair.bg];
+          expect(fg, `theme "${theme}" is missing token ${pair.fg}`).toBeTruthy();
+          expect(bg, `theme "${theme}" is missing token ${pair.bg}`).toBeTruthy();
+
+          const ratio = contrastRatio(fg, bg);
+          expect(
+            ratio,
+            `${theme}: ${pair.name} — ${pair.fg} (${fg}) on ${pair.bg} (${bg}) = ` +
+              `${ratio.toFixed(2)}:1, needs >= ${minimum}:1`,
+          ).toBeGreaterThanOrEqual(minimum);
+        });
+      }
+    });
+  }
+});

--- a/src/a11y/themeTokens.ts
+++ b/src/a11y/themeTokens.ts
@@ -1,0 +1,68 @@
+/// <reference types="node" />
+// Resolves each theme's design-token values straight from src/styles/app.css so
+// the accessibility test guards the real stylesheet (no duplicated color list).
+//
+// Tokens are CSS custom properties declared on a small set of theme selectors.
+// We layer them exactly the way themeClass() in the app store applies classes:
+//   dark    -> :root
+//   light   -> :root + .light-theme
+//   aurora  -> :root + .theme-aurora
+//   crimson -> :root + .light-theme + .theme-crimson
+
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+export type ThemeId = 'dark' | 'light' | 'aurora' | 'crimson';
+
+export const THEMES: ThemeId[] = ['dark', 'light', 'aurora', 'crimson'];
+
+// Resolved from the project root (Vitest runs from there). Avoids import.meta.url,
+// which the jsdom test environment reports with a non-file scheme.
+const CSS_PATH = resolve(process.cwd(), 'src/styles/app.css');
+
+const THEME_SELECTORS: Record<ThemeId, string[]> = {
+  dark: [':root'],
+  light: [':root', '.light-theme'],
+  aurora: [':root', '.theme-aurora'],
+  crimson: [':root', '.light-theme', '.theme-crimson'],
+};
+
+let cssCache: string | null = null;
+
+function readCss(): string {
+  cssCache ??= readFileSync(CSS_PATH, 'utf8');
+  return cssCache;
+}
+
+/**
+ * Extract the custom-property declarations from every standalone
+ * `<selector> { ... }` rule (ignoring compound/descendant selectors that merely
+ * mention the class). Later declarations win, mirroring the cascade.
+ */
+function extractVars(css: string, selector: string): Record<string, string> {
+  const vars: Record<string, string> = {};
+  const escaped = selector.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  // The selector must open the rule: preceded by start, `}`, or a comment close.
+  const blockRe = new RegExp(`(?:[}/]|^)\\s*${escaped}\\s*\\{([^}]*)\\}`, 'g');
+  const declRe = /(--[\w-]+)\s*:\s*([^;]+);/g;
+
+  let block: RegExpExecArray | null;
+  while ((block = blockRe.exec(css)) !== null) {
+    const body = block[1];
+    let decl: RegExpExecArray | null;
+    while ((decl = declRe.exec(body)) !== null) {
+      vars[decl[1].trim()] = decl[2].trim();
+    }
+  }
+  return vars;
+}
+
+/** Resolved custom-property map for a theme (token name -> CSS value). */
+export function getThemeTokens(theme: ThemeId): Record<string, string> {
+  const css = readCss();
+  const merged: Record<string, string> = {};
+  for (const selector of THEME_SELECTORS[theme]) {
+    Object.assign(merged, extractVars(css, selector));
+  }
+  return merged;
+}

--- a/src/components/OntologyGraph.tsx
+++ b/src/components/OntologyGraph.tsx
@@ -14,14 +14,14 @@ declare global {
   }
 }
 
-type GraphColors = { nodeText: string; edgeColor: string; edgeText: string };
+type GraphColors = { nodeText: string; edgeColor: string; edgeText: string; edgeLabelBg: string };
 
 // Read graph colors from the active theme's CSS custom properties, falling
 // back to the dark/light defaults when the variables can't be resolved yet.
 function readGraphColors(darkMode: boolean, el?: HTMLElement | null): GraphColors {
   const fallback: GraphColors = darkMode
-    ? { nodeText: '#B3B3B3', edgeColor: '#505050', edgeText: '#808080' }
-    : { nodeText: '#2A2A2A', edgeColor: '#888888', edgeText: '#555555' };
+    ? { nodeText: '#B3B3B3', edgeColor: '#6E6E6E', edgeText: '#9CA0A8', edgeLabelBg: '#15161D' }
+    : { nodeText: '#2A2A2A', edgeColor: '#888888', edgeText: '#555555', edgeLabelBg: '#F2F2F2' };
   const source = el ?? (typeof document !== 'undefined' ? document.querySelector<HTMLElement>('.app-container') : null);
   if (!source) return fallback;
   const cs = getComputedStyle(source);
@@ -29,6 +29,7 @@ function readGraphColors(darkMode: boolean, el?: HTMLElement | null): GraphColor
     nodeText: cs.getPropertyValue('--graph-node-text').trim() || fallback.nodeText,
     edgeColor: cs.getPropertyValue('--graph-edge-color').trim() || fallback.edgeColor,
     edgeText: cs.getPropertyValue('--graph-edge-text').trim() || fallback.edgeText,
+    edgeLabelBg: cs.getPropertyValue('--graph-edge-label-bg').trim() || fallback.edgeLabelBg,
   };
 }
 
@@ -191,8 +192,8 @@ export function OntologyGraph() {
             'text-margin-y': -10,
             'text-wrap': 'ellipsis',
             'text-max-width': '120px',
-            'text-background-color': initialThemeColors.current.nodeText === '#B3B3B3' ? '#1a1a2e' : '#f5f5f5',
-            'text-background-opacity': 0.75,
+            'text-background-color': initialThemeColors.current.edgeLabelBg,
+            'text-background-opacity': 1,
             'text-background-padding': '2px',
             'text-background-shape': 'roundrectangle',
             'width': 3,
@@ -381,7 +382,7 @@ export function OntologyGraph() {
     try {
       // Apply text-color update to ALL edges/nodes (text colors don't affect highlight line-color)
       cy.$('node').style({ 'color': themeColors.nodeText });
-      cy.$('edge').style({ 'color': themeColors.edgeText, 'text-background-color': darkMode ? '#1a1a2e' : '#f5f5f5' });
+      cy.$('edge').style({ 'color': themeColors.edgeText, 'text-background-color': themeColors.edgeLabelBg, 'text-background-opacity': 1 });
       // Line/arrow colors: only update non-highlighted edges so path-finder highlights survive
       cy.edges().not('.highlighted').style({
         'line-color': themeColors.edgeColor,

--- a/src/components/designer/DesignerPreview.tsx
+++ b/src/components/designer/DesignerPreview.tsx
@@ -76,8 +76,9 @@ function GraphPreview({ ontology, theme, onSelectEntity, onSelectRelationship }:
     const cssVars = getComputedStyle(containerRef.current);
     const themeColors = {
       nodeText: cssVars.getPropertyValue('--graph-node-text').trim() || '#B3B3B3',
-      edgeColor: cssVars.getPropertyValue('--graph-edge-color').trim() || '#505050',
-      edgeText: cssVars.getPropertyValue('--graph-edge-text').trim() || '#808080',
+      edgeColor: cssVars.getPropertyValue('--graph-edge-color').trim() || '#6E6E6E',
+      edgeText: cssVars.getPropertyValue('--graph-edge-text').trim() || '#9CA0A8',
+      edgeLabelBg: cssVars.getPropertyValue('--graph-edge-label-bg').trim() || '#15161D',
     };
     const cy = cytoscape({
       container: containerRef.current,
@@ -111,6 +112,10 @@ function GraphPreview({ ontology, theme, onSelectEntity, onSelectRelationship }:
             color: themeColors.edgeText,
             'text-rotation': 'autorotate',
             'text-margin-y': -8,
+            'text-background-color': themeColors.edgeLabelBg,
+            'text-background-opacity': 1,
+            'text-background-padding': '2px',
+            'text-background-shape': 'roundrectangle',
             width: 2,
             'line-color': themeColors.edgeColor,
             'target-arrow-color': themeColors.edgeColor,

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -20,9 +20,11 @@
   --bg-elevated: #323232;
   --text-primary: #FFFFFF;
   --text-secondary: #B3B3B3;
-  --text-tertiary: #808080;
+  --text-tertiary: #A0A0A0;
   --border-color: #404040;
   --border-subtle: #333333;
+  /* Foreground for accent-colored fills (e.g. buttons on var(--ms-blue)) */
+  --on-accent: #FFFFFF;
   
   /* Semantic Colors */
   --success: #107C10;
@@ -54,8 +56,9 @@
   /* Graph-specific dark mode colors */
   --graph-bg: #1E1E1E;
   --graph-node-text: #B3B3B3;
-  --graph-edge-color: #505050;
-  --graph-edge-text: #808080;
+  --graph-edge-color: #6E6E6E;
+  --graph-edge-text: #9CA0A8;
+  --graph-edge-label-bg: #15161D;
   
   /* Chess board pattern colors for dark mode - futuristic theme */
   --chess-square-dark: rgba(20, 30, 50, 0.85);
@@ -84,6 +87,7 @@
   --graph-node-text: #2A2A2A;
   --graph-edge-color: #888888;
   --graph-edge-text: #555555;
+  --graph-edge-label-bg: #F2F2F2;
   
   /* Chess board pattern colors for light mode - futuristic theme */
   --chess-square-dark: rgba(220, 230, 245, 0.8);
@@ -106,9 +110,12 @@
   --bg-elevated: #173E37;
   --text-primary: #EAFBF6;
   --text-secondary: #A6D2C8;
-  --text-tertiary: #779E95;
+  --text-tertiary: #8AB0A6;
   --border-color: #265C53;
   --border-subtle: #1C4640;
+  /* Aurora's accent is mint (#2AAA92); white text on it fails AA, so accent
+     fills use a deep teal foreground instead. */
+  --on-accent: #08221D;
 
   --shadow-glow: 0 0 20px rgba(42, 170, 146, 0.35);
 
@@ -116,6 +123,7 @@
   --graph-node-text: #C2E6DC;
   --graph-edge-color: #4F8C7F;
   --graph-edge-text: #8FBDB2;
+  --graph-edge-label-bg: #0C2622;
 
   --chess-square-dark: rgba(8, 40, 36, 0.85);
   --chess-square-light: rgba(16, 64, 58, 0.6);
@@ -136,7 +144,7 @@
   --bg-elevated: #FFFFFF;
   --text-primary: #1B1F24;
   --text-secondary: #495057;
-  --text-tertiary: #6C757D;
+  --text-tertiary: #656D75;
   --border-color: #D6DAE0;
   --border-subtle: #E3E6EA;
 
@@ -144,8 +152,9 @@
 
   --graph-bg: #FFFFFF;
   --graph-node-text: #1B1F24;
-  --graph-edge-color: #ADB5BD;
-  --graph-edge-text: #6C757D;
+  --graph-edge-color: #8A9198;
+  --graph-edge-text: #646B72;
+  --graph-edge-label-bg: #FBF7F8;
 
   /* Opaque light base so the canvas reads light (the dark body must not show
      through); faint crimson squares keep the branded checker pattern. */
@@ -414,7 +423,7 @@ body {
 .header-text-btn:hover {
   background: var(--ms-blue);
   border-color: var(--ms-blue);
-  color: white;
+  color: var(--on-accent);
 }
 
 /* Left Panel - Quest Panel */
@@ -614,7 +623,7 @@ body {
 
 .btn-primary {
   background: var(--ms-blue);
-  color: white;
+  color: var(--on-accent);
 }
 
 .btn-primary:hover {
@@ -684,7 +693,7 @@ body {
 
 .graph-control-btn:hover {
   background: var(--ms-blue);
-  color: white;
+  color: var(--on-accent);
   border-color: var(--ms-blue);
 }
 
@@ -1032,7 +1041,7 @@ body {
   justify-content: center;
   background: var(--ms-blue);
   border-radius: var(--radius-sm);
-  color: white;
+  color: var(--on-accent);
   font-size: 16px;
 }
 
@@ -2196,7 +2205,7 @@ body {
   gap: 4px;
   padding: 4px 10px;
   background: var(--ms-blue);
-  color: white;
+  color: var(--on-accent);
   border: none;
   border-radius: var(--radius-sm);
   font-size: 12px;
@@ -2531,7 +2540,7 @@ body {
 }
 .designer-toolbar-btn:hover {
   background: var(--ms-blue);
-  color: white;
+  color: var(--on-accent);
   border-color: var(--ms-blue);
 }
 .designer-toolbar-btn:disabled {
@@ -2626,7 +2635,7 @@ body {
 }
 .designer-action-btn.primary {
   background: var(--ms-blue);
-  color: white;
+  color: var(--on-accent);
 }
 .designer-action-btn.primary:hover { background: var(--ms-blue-dark); }
 .designer-action-btn.secondary {
@@ -2986,7 +2995,7 @@ body {
   border-radius: 14px;
   padding: 0 10px;
   background: var(--ms-blue);
-  color: #fff;
+  color: var(--on-accent);
   font: 700 12px/1 var(--font-primary);
   margin-bottom: 12px;
   white-space: nowrap;
@@ -3281,7 +3290,7 @@ body {
 .learn-present-btn:hover {
   border-color: var(--ms-blue);
   background: var(--ms-blue);
-  color: #fff;
+  color: var(--on-accent);
 }
 
 /* --- Presentation overlay --- */
@@ -3905,7 +3914,7 @@ body {
   align-items: center;
   justify-content: center;
   background: var(--ms-blue);
-  color: white;
+  color: var(--on-accent);
   font-size: 10px;
   font-weight: 700;
   border-radius: 10px;
@@ -4175,7 +4184,7 @@ body {
 
 .tour-btn-primary {
   background: var(--ms-blue);
-  color: #fff;
+  color: var(--on-accent);
 }
 
 .tour-btn-primary:hover {
@@ -4528,7 +4537,7 @@ body {
   gap: 5px;
   padding: 7px 12px;
   background: var(--ms-blue);
-  color: white;
+  color: var(--on-accent);
   border: none;
   border-radius: var(--radius-sm);
   font-family: inherit;


### PR DESCRIPTION
## Summary

Audits and fixes color-contrast accessibility across all four themes (dark, light, aurora, crimson) to **WCAG 2.1 Level AA** — the bar Microsoft's Accessibility Insights / axe-core enforces — and adds a CI gate so future theme/UI changes can't regress it.

## Standard

- **SC 1.4.3** normal text ≥ **4.5:1**
- **SC 1.4.11** UI components & graphical objects (graph edges) ≥ **3:1**

## Diagnosis

A new deterministic suite (`src/a11y/`) parses the real `app.css`, resolves each theme's tokens, and asserts every text/non-text pair — including the canvas graph colors that axe can't see in the DOM. First run surfaced **14 failures**.

| Theme | Problem | Was | Now |
|---|---|---|---|
| dark | muted text | 3.49 / 4.36:1 | `#A0A0A0` ✓ |
| dark | graph edge line | 2.07:1 | `#6E6E6E` ✓ |
| aurora | muted text | 4.499:1 | `#8AB0A6` ✓ |
| aurora | white-on-mint buttons | 2.89:1 | `--on-accent: #08221D` ✓ |
| crimson | muted text | 4.45:1 | `#656D75` ✓ |
| crimson | graph edge line | 2.07:1 | `#8A9198` ✓ |

## Changes

- Adjusted failing token values in `src/styles/app.css` for dark, aurora, crimson (light already passed).
- Added two tokens: `--on-accent` (accent-button label color) and per-theme opaque `--graph-edge-label-bg` (edge-label chip).
- Wired 12 solid-accent controls to `var(--on-accent)` — no-op in the white-on-accent themes, the real fix for aurora.
- Replaced a brittle hardcoded edge-label-chip ternary in `OntologyGraph.tsx` and `DesignerPreview.tsx` with the new token.
- **CI gate:** new `npm run test:a11y` script + dedicated "Accessibility — WCAG 2.1 AA contrast" step in `ci.yml`.
- Docs: theme-authoring guide + skill updated with the contrast contract; `TODO.md` item checked off.

## Verification

- **48/48** contrast checks pass.
- Full local gate green: `catalogue:build`, `learn:build`, `validate`, `tsc -b`, `npm test` (358 passed), `vite build`.