### PR TITLE
fix(a11y): WCAG 2.1 AA contrast for inspector stat-card icons

### DIFF
--- a/.github/skills/theme-authoring/SKILL.md
+++ b/.github/skills/theme-authoring/SKILL.md
@@ -56,6 +56,8 @@ Make all edits in [`src/store/appStore.ts`](../../../src/store/appStore.ts) and
   other non-text need 3:1. Set `--on-accent` (label color on accent fills) to a
   **dark** value for a **light** accent (white fails on Aurora's mint) and white
   for a dark accent. Edge text must clear 4.5:1 against `--graph-edge-label-bg`.
+  Stat-tile icons/values (`--stat-blue/green/purple`) need 3:1 over the tint and
+  cascade automatically (bright from `:root`, dark from `.light-theme`).
   `npm run test:a11y` enforces this for every theme. (Guide → Accessibility.)
 - **Register dark themes** in `DARK_BASED_THEMES` so `darkMode` is correct
   (graph fallback, label backplate, PNG export bg).

--- a/docs/theme-authoring-guide.md
+++ b/docs/theme-authoring-guide.md
@@ -75,6 +75,7 @@ over it).
 | --- | --- | --- |
 | Accent | `--ms-blue`, `--ms-blue-dark`, `--ms-blue-light`, `--info` | Primary accent used across buttons, links, highlights. Override these to re-brand the accent color. |
 | Accent foreground | `--on-accent` | Text/icon color placed **on** an accent-colored fill (e.g. `.btn-primary`). Must clear 4.5:1 against `--ms-blue`. White suits a dark accent; a **light** accent (e.g. Aurora's mint) needs a **dark** value. Inherited from `:root` (white) unless overridden. |
+| Stat tiles | `--stat-blue`, `--stat-green`, `--stat-purple` | Icon + value color for the Ontology-Insights metric tiles, which lay a translucent tint over `--bg-secondary`. Each must clear **3:1** against its composited tile. Dark-based themes inherit the **bright** `:root` set; light-based themes inherit the **darker** `.light-theme` set — override only if your sidebar uses an unusual background. |
 | Surfaces | `--bg-primary`, `--bg-secondary`, `--bg-tertiary`, `--bg-elevated` | Page and panel backgrounds, lightest → most elevated. |
 | Text | `--text-primary`, `--text-secondary`, `--text-tertiary` | Foreground text, primary → muted. |
 | Borders | `--border-color`, `--border-subtle` | Panel/control borders. |
@@ -266,6 +267,10 @@ themes, so a new theme or a token tweak can't silently ship a failing color:
   against the opaque `--graph-edge-label-bg` chip.
 - **Graph edge lines** (`--graph-edge-color`) are graphical objects and need
   **3:1** against `--graph-bg` (SC 1.4.11 Non-text Contrast).
+- **Stat-card tiles** — the metric icons and bold values (`--stat-blue`,
+  `--stat-green`, `--stat-purple`) are graphical objects / large text and need
+  **3:1** against the translucent tile, composited over `--bg-secondary`. Keep
+  the icons at full opacity (a `0.7` fade drops them below the floor).
 
 Thresholds are floors — `4.49:1` fails.
 

--- a/src/a11y/themeContrast.test.ts
+++ b/src/a11y/themeContrast.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { contrastRatio, AA_NORMAL_TEXT, AA_NON_TEXT } from './contrast';
+import { contrastRatio, AA_NORMAL_TEXT, AA_NON_TEXT, composite, parseColor } from './contrast';
 import { THEMES, getThemeTokens } from './themeTokens';
 
 // Microsoft's accessibility bar is WCAG 2.1 Level AA. This suite enforces the
@@ -55,6 +55,58 @@ describe('WCAG 2.1 AA theme contrast (SC 1.4.3 / 1.4.11)', () => {
             `${theme}: ${pair.name} — ${pair.fg} (${fg}) on ${pair.bg} (${bg}) = ` +
               `${ratio.toFixed(2)}:1, needs >= ${minimum}:1`,
           ).toBeGreaterThanOrEqual(minimum);
+        });
+      }
+    });
+  }
+});
+
+// ── Stat-card metric tiles (OntologyStatsPanel) ──────────────────────────────
+// Each colored tile lays a translucent tint over the sidebar (--bg-secondary).
+// The icon (graphical object, SC 1.4.11) and the 22px-bold value (large text,
+// SC 1.4.3) share a per-theme accent token and must clear 3:1 against the
+// *composited* tile background — guarding against a re-introduced opacity fade
+// or an off-contrast token in any current or future theme.
+const STAT_TILES = ['blue', 'purple', 'green'] as const;
+
+const STAT_TILE_TINT: Record<(typeof STAT_TILES)[number], string> = {
+  blue: 'rgba(0, 120, 212, 0.12)',
+  purple: 'rgba(92, 45, 145, 0.12)',
+  green: 'rgba(16, 124, 16, 0.12)',
+};
+
+const STAT_TILE_FG: Record<(typeof STAT_TILES)[number], string> = {
+  blue: '--stat-blue',
+  purple: '--stat-purple',
+  green: '--stat-green',
+};
+
+function flatten(tint: string, baseHex: string): string {
+  const { r, g, b } = composite(parseColor(tint), parseColor(baseHex));
+  const hex = (n: number) => n.toString(16).padStart(2, '0');
+  return `#${hex(r)}${hex(g)}${hex(b)}`;
+}
+
+describe('WCAG 2.1 AA stat-card tiles (SC 1.4.11 / 1.4.3)', () => {
+  for (const theme of THEMES) {
+    const tokens = getThemeTokens(theme);
+
+    describe(theme, () => {
+      const sidebar = tokens['--bg-secondary'];
+
+      for (const tile of STAT_TILES) {
+        it(`${tile} tile icon & value meet ${AA_NON_TEXT}:1`, () => {
+          const fg = tokens[STAT_TILE_FG[tile]];
+          expect(fg, `theme "${theme}" is missing token ${STAT_TILE_FG[tile]}`).toBeTruthy();
+          expect(sidebar, `theme "${theme}" is missing token --bg-secondary`).toBeTruthy();
+
+          const tileBg = flatten(STAT_TILE_TINT[tile], sidebar);
+          const ratio = contrastRatio(fg, tileBg);
+          expect(
+            ratio,
+            `${theme}: ${tile} stat tile — ${STAT_TILE_FG[tile]} (${fg}) on composited ` +
+              `${tileBg} = ${ratio.toFixed(2)}:1, needs >= ${AA_NON_TEXT}:1`,
+          ).toBeGreaterThanOrEqual(AA_NON_TEXT);
         });
       }
     });

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -25,6 +25,11 @@
   --border-subtle: #333333;
   /* Foreground for accent-colored fills (e.g. buttons on var(--ms-blue)) */
   --on-accent: #FFFFFF;
+  /* Stat-card metric icon/value foregrounds — WCAG 2.1 AA (>=3:1) on the
+     translucent tiles over a dark sidebar (dark + aurora themes). */
+  --stat-blue: #5CB0F2;
+  --stat-green: #3FB950;
+  --stat-purple: #C4A2F0;
   
   /* Semantic Colors */
   --success: #107C10;
@@ -78,6 +83,10 @@
   --text-tertiary: #666666;
   --border-color: #C0C0C0;
   --border-subtle: #D8D8D8;
+  /* Stat-card foregrounds for a light sidebar (light + crimson themes). */
+  --stat-blue: #0067C0;
+  --stat-green: #107C10;
+  --stat-purple: #7A3FBF;
   --shadow-sm: 0 2px 4px rgba(0, 0, 0, 0.08);
   --shadow-md: 0 4px 8px rgba(0, 0, 0, 0.1);
   --shadow-lg: 0 8px 16px rgba(0, 0, 0, 0.12);
@@ -3814,12 +3823,12 @@ body {
 }
 
 .stat-card-icon {
-  opacity: 0.7;
+  opacity: 1;
 }
 
-.stat-card--blue .stat-card-icon { color: var(--ms-blue); }
-.stat-card--purple .stat-card-icon { color: #8a52d4; }
-.stat-card--green .stat-card-icon { color: var(--ms-green-light); }
+.stat-card--blue .stat-card-icon { color: var(--stat-blue); }
+.stat-card--purple .stat-card-icon { color: var(--stat-purple); }
+.stat-card--green .stat-card-icon { color: var(--stat-green); }
 
 .stat-card-value {
   font-size: 22px;
@@ -3827,9 +3836,9 @@ body {
   line-height: 1;
 }
 
-.stat-card--blue .stat-card-value { color: var(--ms-blue); }
-.stat-card--purple .stat-card-value { color: #8a52d4; }
-.stat-card--green .stat-card-value { color: var(--ms-green-light); }
+.stat-card--blue .stat-card-value { color: var(--stat-blue); }
+.stat-card--purple .stat-card-value { color: var(--stat-purple); }
+.stat-card--green .stat-card-value { color: var(--stat-green); }
 
 .stat-card-label {
   font-size: 10px;


### PR DESCRIPTION
## Problem

In the **Ontology Insights** panel (right sidebar), the metric stat-card icons
(Layers / Link / Network) and their numbers were washed out and hard to see —
reported as an accessibility gap. A `.stat-card-icon { opacity: 0.7 }` fade plus
mid-tone fills left the icons **below the WCAG 2.1 AA 3:1 non-text floor**
(e.g. light theme blue ≈ 2.53:1, green ≈ 2.37:1).

## Fix

- **Per-theme foreground tokens** `--stat-blue` / `--stat-green` / `--stat-purple`:
  bright values in `:root` (for the dark **dark**/**aurora** sidebars), darker
  values in `.light-theme` (for the pale **light**/**crimson** sidebars). A single
  color couldn't pass both — `#0078D4` is only ~2.7:1 on the dark tile even at full
  opacity. Wired to both the icon and the value.
- **Removed the `opacity: 0.7` fade** on `.stat-card-icon` (full opacity).
- **Regression test** in `themeContrast.test.ts`: composites each translucent tile
  tint over its `--bg-secondary` base and asserts the foreground clears **3:1** —
  12 new checks (4 themes × 3 tiles).
- Documented the new tokens in the theme-authoring guide + skill.

## Verification

- `npm run test:a11y` → **60 passed** (48 prior + 12 new).
- Full local gate green: catalogue/learn build, validate, `tsc -b`, `npm test`
  (370 passed), `vite build`.
- Visually confirmed in **dark** and **light**: icons + numbers now crisp.