### PR TITLE
fix(a11y): theme-aware amber + progress-bar contrast; drop dead stats CSS

### DIFF
--- a/.github/skills/theme-authoring/SKILL.md
+++ b/.github/skills/theme-authoring/SKILL.md
@@ -57,7 +57,10 @@ Make all edits in [`src/store/appStore.ts`](../../../src/store/appStore.ts) and
   **dark** value for a **light** accent (white fails on Aurora's mint) and white
   for a dark accent. Edge text must clear 4.5:1 against `--graph-edge-label-bg`.
   Stat-tile icons/values (`--stat-blue/green/purple`) need 3:1 over the tint and
-  cascade automatically (bright from `:root`, dark from `.light-theme`).
+  cascade automatically (bright from `:root`, dark from `.light-theme`). Amber
+  text/icons use `--ms-yellow-fg` (bright `#FFB900` on dark, dark gold `#8A6A00`
+  on light); the `.progress-fill` stops `--progress-from`/`--progress-to` each
+  need 3:1 on the `--bg-tertiary` track.
   `npm run test:a11y` enforces this for every theme. (Guide → Accessibility.)
 - **Register dark themes** in `DARK_BASED_THEMES` so `darkMode` is correct
   (graph fallback, label backplate, PNG export bg).

--- a/docs/theme-authoring-guide.md
+++ b/docs/theme-authoring-guide.md
@@ -76,6 +76,8 @@ over it).
 | Accent | `--ms-blue`, `--ms-blue-dark`, `--ms-blue-light`, `--info` | Primary accent used across buttons, links, highlights. Override these to re-brand the accent color. |
 | Accent foreground | `--on-accent` | Text/icon color placed **on** an accent-colored fill (e.g. `.btn-primary`). Must clear 4.5:1 against `--ms-blue`. White suits a dark accent; a **light** accent (e.g. Aurora's mint) needs a **dark** value. Inherited from `:root` (white) unless overridden. |
 | Stat tiles | `--stat-blue`, `--stat-green`, `--stat-purple` | Icon + value color for the Ontology-Insights metric tiles, which lay a translucent tint over `--bg-secondary`. Each must clear **3:1** against its composited tile. Dark-based themes inherit the **bright** `:root` set; light-based themes inherit the **darker** `.light-theme` set — override only if your sidebar uses an unusual background. |
+| Amber foreground | `--ms-yellow-fg` | Color for amber **text + icons** — header points/badges, quest points, the pathfinder warning, the active designer-ID toggle. As text it must clear **4.5:1**. Dark-based themes inherit the bright `:root` `#FFB900`; light-based themes inherit the darker `.light-theme` gold (`#8A6A00`), because bright amber fails (~1.7:1) on white. Distinct from the brand **fill** `--ms-yellow` (paired with black text) — don't conflate them. |
+| Progress fill | `--progress-from`, `--progress-to` | The two gradient stops of `.progress-fill`, painted over the `--bg-tertiary` track. **Both** must clear **3:1** against that track (SC 1.4.11). Bright on dark-based themes; the accent/violet pair on `.light-theme`; Aurora and Crimson override `--progress-from` to keep their signature hue. |
 | Surfaces | `--bg-primary`, `--bg-secondary`, `--bg-tertiary`, `--bg-elevated` | Page and panel backgrounds, lightest → most elevated. |
 | Text | `--text-primary`, `--text-secondary`, `--text-tertiary` | Foreground text, primary → muted. |
 | Borders | `--border-color`, `--border-subtle` | Panel/control borders. |
@@ -153,6 +155,9 @@ light) and retune. Place it after the existing theme blocks.
   --ms-blue-light: #6366F1;
   --info: #4F46E5;
   --on-accent: #FFFFFF;       /* white clears 4.5:1 on this indigo accent */
+  --ms-yellow-fg: #FFB900;    /* amber text/icons; a light theme needs ~#8A6A00 */
+  --progress-from: #818CF8;   /* both progress stops need 3:1 on --bg-tertiary */
+  --progress-to: #C4B5FD;
 
   --bg-primary: #15172B;
   --bg-secondary: #1C1F3A;
@@ -271,6 +276,13 @@ themes, so a new theme or a token tweak can't silently ship a failing color:
   `--stat-green`, `--stat-purple`) are graphical objects / large text and need
   **3:1** against the translucent tile, composited over `--bg-secondary`. Keep
   the icons at full opacity (a `0.7` fade drops them below the floor).
+- **Amber text + icons** (`--ms-yellow-fg`) — header points/badges, quest
+  points, the pathfinder warning, the active designer-ID toggle — are normal
+  text and need **4.5:1** against their surface. Bright amber only clears this
+  on dark backgrounds, so light-based themes drop it to a darker gold.
+- **Progress-bar fill** (`--progress-from`, `--progress-to`) — both gradient
+  stops are graphical objects and need **3:1** against the `--bg-tertiary`
+  track (SC 1.4.11).
 
 Thresholds are floors — `4.49:1` fails.
 

--- a/src/a11y/themeContrast.test.ts
+++ b/src/a11y/themeContrast.test.ts
@@ -112,3 +112,73 @@ describe('WCAG 2.1 AA stat-card tiles (SC 1.4.11 / 1.4.3)', () => {
     });
   }
 });
+
+// ── Amber foreground token (--ms-yellow-fg) ──────────────────────────────────
+// #FFB900 reads on the dark themes but fails on light surfaces (~1.7:1), so the
+// light themes override it to a darker gold. It colors text + icons: header
+// points/badges (.stat-value), quest points, the pathfinder warning message,
+// and the active designer ID toggle. Guard it as normal text (4.5:1) against
+// every surface it lands on, including the translucent amber warn tile.
+const WARN_TINT = 'rgba(255, 185, 0, 0.1)'; // .pathfinder-message--warn / .designer-id-btn.active
+
+describe('WCAG 2.1 AA amber foreground (SC 1.4.3)', () => {
+  for (const theme of THEMES) {
+    const tokens = getThemeTokens(theme);
+
+    describe(theme, () => {
+      const fg = tokens['--ms-yellow-fg'];
+      const surfaces: { name: string; bg: string }[] = [
+        { name: 'panel', bg: tokens['--bg-secondary'] },
+        { name: 'elevated surface', bg: tokens['--bg-elevated'] },
+        { name: 'app background', bg: tokens['--bg-primary'] },
+        { name: 'warn tile', bg: flatten(WARN_TINT, tokens['--bg-secondary']) },
+      ];
+
+      for (const s of surfaces) {
+        it(`amber text on ${s.name} meets ${AA_NORMAL_TEXT}:1`, () => {
+          expect(fg, `theme "${theme}" is missing token --ms-yellow-fg`).toBeTruthy();
+          expect(s.bg, `theme "${theme}" is missing a surface token`).toBeTruthy();
+
+          const ratio = contrastRatio(fg, s.bg);
+          expect(
+            ratio,
+            `${theme}: amber text — --ms-yellow-fg (${fg}) on ${s.name} (${s.bg}) = ` +
+              `${ratio.toFixed(2)}:1, needs >= ${AA_NORMAL_TEXT}:1`,
+          ).toBeGreaterThanOrEqual(AA_NORMAL_TEXT);
+        });
+      }
+    });
+  }
+});
+
+// ── Progress-bar fill vs track (SC 1.4.11) ───────────────────────────────────
+// .progress-fill paints a gradient between --progress-from and --progress-to
+// over the --bg-tertiary track. Both stops must clear 3:1 against the track so
+// the filled portion stays distinguishable (the mid-tone accent + purple failed
+// on the dark themes before these stops were split per theme).
+const PROGRESS_STOPS = ['--progress-from', '--progress-to'] as const;
+
+describe('WCAG 2.1 AA progress-bar fill (SC 1.4.11)', () => {
+  for (const theme of THEMES) {
+    const tokens = getThemeTokens(theme);
+
+    describe(theme, () => {
+      const track = tokens['--bg-tertiary'];
+
+      for (const stop of PROGRESS_STOPS) {
+        it(`${stop} on track meets ${AA_NON_TEXT}:1`, () => {
+          const fg = tokens[stop];
+          expect(fg, `theme "${theme}" is missing token ${stop}`).toBeTruthy();
+          expect(track, `theme "${theme}" is missing token --bg-tertiary`).toBeTruthy();
+
+          const ratio = contrastRatio(fg, track);
+          expect(
+            ratio,
+            `${theme}: progress fill — ${stop} (${fg}) on --bg-tertiary (${track}) = ` +
+              `${ratio.toFixed(2)}:1, needs >= ${AA_NON_TEXT}:1`,
+          ).toBeGreaterThanOrEqual(AA_NON_TEXT);
+        });
+      }
+    });
+  }
+});

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -30,6 +30,13 @@
   --stat-blue: #5CB0F2;
   --stat-green: #3FB950;
   --stat-purple: #C4A2F0;
+  /* Foreground for amber icons + text. Bright amber reads on the dark surfaces
+     (dark + aurora); light themes override to a darker gold for >=4.5:1 text. */
+  --ms-yellow-fg: #FFB900;
+  /* Progress-bar fill stops — must clear 3:1 against the --bg-tertiary track
+     (SC 1.4.11). Bright on the dark track; light themes use accent + purple. */
+  --progress-from: #4DA6FF;
+  --progress-to: #B98EE6;
   
   /* Semantic Colors */
   --success: #107C10;
@@ -87,6 +94,11 @@
   --stat-blue: #0067C0;
   --stat-green: #107C10;
   --stat-purple: #7A3FBF;
+  /* Amber fails on light surfaces; a darker gold clears >=4.5:1 on white. */
+  --ms-yellow-fg: #8A6A00;
+  /* Light track is pale, so the accent + purple already clear 3:1. */
+  --progress-from: #0078D4;
+  --progress-to: #5C2D91;
   --shadow-sm: 0 2px 4px rgba(0, 0, 0, 0.08);
   --shadow-md: 0 4px 8px rgba(0, 0, 0, 0.1);
   --shadow-lg: 0 8px 16px rgba(0, 0, 0, 0.12);
@@ -112,6 +124,8 @@
   --ms-blue-light: #3FD0B4;
   --info: #2AAA92;
   --ms-cyan: #6AD6F9;
+  /* Keep the mint accent as the progress-bar start (clears 3:1 on the track). */
+  --progress-from: #2AAA92;
 
   --bg-primary: #0E2B27;
   --bg-secondary: #14352F;
@@ -146,6 +160,8 @@
   --ms-blue-dark: #A8001F;
   --ms-blue-light: #E63956;
   --info: #D6002A;
+  /* Crimson accent as the progress-bar start (clears 3:1 on the light track). */
+  --progress-from: #D6002A;
 
   --bg-primary: #F8F9FA;
   --bg-secondary: #FFFFFF;
@@ -357,7 +373,7 @@ body {
 
 .stat-value {
   font-weight: 600;
-  color: var(--ms-yellow);
+  color: var(--ms-yellow-fg);
 }
 
 .header-actions {
@@ -542,7 +558,7 @@ body {
 }
 
 .quest-points {
-  color: var(--ms-yellow);
+  color: var(--ms-yellow-fg);
   font-weight: 600;
 }
 
@@ -582,7 +598,7 @@ body {
 
 .progress-fill {
   height: 100%;
-  background: linear-gradient(90deg, var(--ms-blue), var(--ms-purple));
+  background: linear-gradient(90deg, var(--progress-from), var(--progress-to));
   transition: width var(--transition-normal);
 }
 
@@ -2470,8 +2486,8 @@ body {
   transition: all var(--transition-fast);
 }
 .designer-id-btn.active {
-  color: var(--ms-yellow);
-  border-color: var(--ms-yellow);
+  color: var(--ms-yellow-fg);
+  border-color: var(--ms-yellow-fg);
   background: rgba(255, 185, 0, 0.1);
 }
 
@@ -3848,142 +3864,6 @@ body {
   letter-spacing: 0.4px;
 }
 
-/* Connectivity progress bar */
-.stats-metric {
-  display: flex;
-  flex-direction: column;
-  gap: 5px;
-}
-
-.stats-metric-header {
-  display: flex;
-  align-items: center;
-  gap: 5px;
-  font-size: 12px;
-  color: var(--text-secondary);
-}
-
-.stats-metric-header svg {
-  flex-shrink: 0;
-  color: var(--ms-yellow);
-}
-
-.stats-metric-value {
-  margin-left: auto;
-  font-weight: 600;
-  color: var(--ms-yellow);
-}
-
-.stats-progress-track {
-  height: 5px;
-  background: var(--bg-tertiary);
-  border-radius: 3px;
-  overflow: hidden;
-}
-
-.stats-progress-fill {
-  height: 100%;
-  background: linear-gradient(90deg, var(--ms-blue), var(--ms-purple));
-  border-radius: 3px;
-  transition: width var(--transition-normal);
-}
-
-/* Highlight rows (most connected, avg properties) */
-.stats-highlight {
-  display: flex;
-  align-items: center;
-  gap: 6px;
-  font-size: 12px;
-  color: var(--text-secondary);
-  padding: 5px 8px;
-  background: var(--bg-tertiary);
-  border-radius: var(--radius-sm);
-}
-
-.stats-highlight svg {
-  flex-shrink: 0;
-  color: var(--ms-yellow);
-}
-
-.stats-highlight-label {
-  flex-shrink: 0;
-}
-
-.stats-highlight-value {
-  margin-left: auto;
-  font-weight: 600;
-  color: var(--text-primary);
-  display: flex;
-  align-items: center;
-  gap: 4px;
-}
-
-.stats-highlight-badge {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  background: var(--ms-blue);
-  color: var(--on-accent);
-  font-size: 10px;
-  font-weight: 700;
-  border-radius: 10px;
-  padding: 1px 6px;
-  min-width: 20px;
-}
-
-/* Property type distribution */
-.stats-type-dist {
-  display: flex;
-  flex-direction: column;
-  gap: 5px;
-}
-
-.stats-type-dist-title {
-  font-size: 11px;
-  font-weight: 600;
-  color: var(--text-tertiary);
-  text-transform: uppercase;
-  letter-spacing: 0.4px;
-  margin-bottom: 2px;
-}
-
-.stats-type-row {
-  display: flex;
-  align-items: center;
-  gap: 6px;
-  font-size: 11px;
-}
-
-.stats-type-name {
-  width: 55px;
-  flex-shrink: 0;
-  color: var(--text-secondary);
-  text-transform: capitalize;
-}
-
-.stats-type-bar-track {
-  flex: 1;
-  height: 4px;
-  background: var(--bg-tertiary);
-  border-radius: 2px;
-  overflow: hidden;
-}
-
-.stats-type-bar-fill {
-  height: 100%;
-  background: var(--ms-blue);
-  border-radius: 2px;
-  min-width: 2px;
-  transition: width var(--transition-normal);
-}
-
-.stats-type-count {
-  width: 20px;
-  text-align: right;
-  color: var(--text-tertiary);
-  flex-shrink: 0;
-}
-
 /* Light theme adjustments for stat cards */
 .light-theme .stat-card--blue {
   background: rgba(0, 120, 212, 0.08);
@@ -3993,9 +3873,6 @@ body {
 }
 .light-theme .stat-card--green {
   background: rgba(16, 124, 16, 0.08);
-}
-.light-theme .stats-highlight {
-  background: var(--bg-tertiary);
 }
 
 .command-palette-input {
@@ -4596,7 +4473,7 @@ body {
 .pathfinder-message--warn {
   background: rgba(255, 185, 0, 0.1);
   border: 1px solid rgba(255, 185, 0, 0.3);
-  color: var(--ms-yellow);
+  color: var(--ms-yellow-fg);
 }
 
 /* Result chain */


### PR DESCRIPTION
## Summary
Broader WCAG 2.1 AA non-text/text contrast pass following the stat-card icon fix (#77).

### Amber text + icons (SC 1.4.3)
`--ms-yellow` (#FFB900) is defined only in `:root`, so it stayed bright on **every** theme. As text/icons it failed AA (~1.7:1) on the light and crimson surfaces (header points/badges, quest points, the pathfinder warning, the active designer-ID toggle). Added a theme-aware **`--ms-yellow-fg`** — bright #FFB900 on dark/aurora, dark gold **#8A6A00** on light/crimson — and repointed those four usages. The brand **fill** `--ms-yellow` (paired with black text on badges) is left untouched.

### Progress-bar fill (SC 1.4.11)
The `.progress-fill` blue→purple gradient dropped below 3:1 on the dark/aurora `--bg-tertiary` track. Added **`--progress-from`/`--progress-to`** per theme (aurora/crimson keep their signature hue) so both gradient stops clear 3:1 everywhere.

### Dead CSS
Removed the unused `.stats-*` detailed-metrics block (~130 lines, zero component refs) — including the orphaned yellow stat icons.

## Tests
- `themeContrast.test.ts`: **+24 assertions** (amber ≥4.5:1 on every surface incl. the translucent warn tile; both progress stops ≥3:1) across all four themes — **84/84** a11y pass.
- Full gate green: catalogue/learn/validate, `tsc -b`, **394** tests, `vite build`.

## Docs
Theme-authoring guide (token table + worked example + accessibility bullets) and the theme-authoring skill document the new tokens.