### PR TITLE
Community ontology: Elements of Software

### DIFF
--- a/catalogue/community/daocoding/elements-of-software/elements-of-software.rdf
+++ b/catalogue/community/daocoding/elements-of-software/elements-of-software.rdf
@@ -9,7 +9,7 @@
 
     <owl:Ontology rdf:about="http://example.org/ontology/elements-of-software/">
         <rdfs:label>Elements of Software</rdfs:label>
-        <rdfs:comment>The essential entities of any SaaS product, modeled with ontological discipline. Demonstrates the patterns that keep a schema honest: parties instead of person-shaped duplicates, roles as reified states rather than classes, one Task that nests, pipelines as properties rather than class chains, and views, automations, permissions and the audit trail as first-class records. Software agents are modeled as parties alongside people and organizations.</rdfs:comment>
+        <rdfs:comment>The essential entities of any SaaS product, modeled with ontological discipline. Demonstrates the patterns that keep a schema honest: parties instead of person-shaped duplicates, roles as reified states rather than entity types, one Task that nests, pipelines as properties rather than entity-type chains, and views, automations, permissions and the audit trail as first-class records. Software agents are modeled as parties alongside people and organizations.</rdfs:comment>
     </owl:Ontology>
 
     <!-- ====================== -->
@@ -18,7 +18,7 @@
 
     <owl:Class rdf:about="http://example.org/ontology/elements-of-software/Party">
         <rdfs:label>Party</rdfs:label>
-        <rdfs:comment>Anyone who can act: a person, an organization, or a software agent. Relations that any actor may hold point here once — assign a Task to a Party and all three kinds qualify. This single abstraction removes most person-shaped duplicate classes from a schema.</rdfs:comment>
+        <rdfs:comment>Anyone who can act: a person, an organization, or a software agent. Relations that any actor may hold point here once — assign a Task to a Party and all three kinds qualify. This single abstraction removes most person-shaped duplicate entity types from a schema.</rdfs:comment>
         <ont:icon>🎭</ont:icon>
         <ont:color>#5C2D91</ont:color>
     </owl:Class>
@@ -32,7 +32,7 @@
 
     <owl:Class rdf:about="http://example.org/ontology/elements-of-software/Organization">
         <rdfs:label>Organization</rdfs:label>
-        <rdfs:comment>A company, institution, or other legal actor. Company, Account and Vendor are not three classes — they are one Organization playing three different Roles.</rdfs:comment>
+        <rdfs:comment>A company, institution, or other legal actor. Company, Account and Vendor are not three entity types — they are one Organization playing three different Roles.</rdfs:comment>
         <ont:icon>🏢</ont:icon>
         <ont:color>#2E86AB</ont:color>
     </owl:Class>
@@ -46,7 +46,7 @@
 
     <owl:Class rdf:about="http://example.org/ontology/elements-of-software/Role">
         <rdfs:label>Role</rdfs:label>
-        <rdfs:comment>Lead, Customer, Vendor, Employee — not classes, but roles a Party plays for a while, in the context of some Organization. Reifying the role keeps one Person one node while their relationships change. Promoting roles to classes is the most common modeling mistake in business software.</rdfs:comment>
+        <rdfs:comment>Lead, Customer, Vendor, Employee — not entity types, but roles a Party plays for a while, in the context of some Organization. Reifying the role keeps one Person one node while their relationships change. Promoting roles to entity types is the most common modeling mistake in business software.</rdfs:comment>
         <ont:icon>🎫</ont:icon>
         <ont:color>#9B59B6</ont:color>
     </owl:Class>
@@ -67,28 +67,28 @@
 
     <owl:Class rdf:about="http://example.org/ontology/elements-of-software/Task">
         <rdfs:label>Task</rdfs:label>
-        <rdfs:comment>A unit of work. One class with a parent relation replaces Task and Subtask — nesting is a relationship, not a new kind of thing. Assigned to a Party, so a person, a team's org, or an agent can hold it.</rdfs:comment>
+        <rdfs:comment>A unit of work. One entity type with a parent relation replaces Task and Subtask — nesting is a relationship, not a new kind of thing. Assigned to a Party, so a person, a team's org, or an agent can hold it.</rdfs:comment>
         <ont:icon>✅</ont:icon>
         <ont:color>#2ECC71</ont:color>
     </owl:Class>
 
     <owl:Class rdf:about="http://example.org/ontology/elements-of-software/Document">
         <rdfs:label>Document</rdfs:label>
-        <rdfs:comment>Doc, File, Note and Template are formats of one thing: authored content that attaches to work. The kind property distinguishes them; four classes would not.</rdfs:comment>
+        <rdfs:comment>Doc, File, Note and Template are formats of one thing: authored content that attaches to work. The kind property distinguishes them; four entity types would not.</rdfs:comment>
         <ont:icon>📄</ont:icon>
         <ont:color>#95A5A6</ont:color>
     </owl:Class>
 
     <owl:Class rdf:about="http://example.org/ontology/elements-of-software/Product">
         <rdfs:label>Product</rdfs:label>
-        <rdfs:comment>What you sell. A Service is a Product you cannot drop on your foot; a Plan is a Product that recurs. One class, a kind property, and a price.</rdfs:comment>
+        <rdfs:comment>What you sell. A Service is a Product you cannot drop on your foot; a Plan is a Product that recurs. One entity type, a kind property, and a price.</rdfs:comment>
         <ont:icon>🧩</ont:icon>
         <ont:color>#F39C12</ont:color>
     </owl:Class>
 
     <owl:Class rdf:about="http://example.org/ontology/elements-of-software/Deal">
         <rdfs:label>Deal</rdfs:label>
-        <rdfs:comment>A potential transaction moving through a pipeline. The pipeline lives in the stage property — modeling Lead, Opportunity and Deal as separate classes forces a migration every time a prospect advances.</rdfs:comment>
+        <rdfs:comment>A potential transaction moving through a pipeline. The pipeline lives in the stage property — modeling Lead, Opportunity and Deal as separate entity types forces a migration every time a prospect advances.</rdfs:comment>
         <ont:icon>💼</ont:icon>
         <ont:color>#E67E22</ont:color>
     </owl:Class>
@@ -116,7 +116,7 @@
 
     <owl:Class rdf:about="http://example.org/ontology/elements-of-software/Interaction">
         <rdfs:label>Interaction</rdfs:label>
-        <rdfs:comment>An email, call, meeting or chat message: one class, a channel property. Splitting these into four classes duplicates every relation they share — participants, timestamps, the deal they concern.</rdfs:comment>
+        <rdfs:comment>An email, call, meeting or chat message: one entity type, a channel property. Splitting these into four entity types duplicates every relation they share — participants, timestamps, the deal they concern.</rdfs:comment>
         <ont:icon>💬</ont:icon>
         <ont:color>#E91E8C</ont:color>
     </owl:Class>
@@ -241,7 +241,7 @@
         <rdfs:label>kind</rdfs:label>
         <rdfs:domain rdf:resource="http://example.org/ontology/elements-of-software/Role"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
-        <rdfs:comment>The role names that business software usually promotes to classes</rdfs:comment>
+        <rdfs:comment>The role names that business software usually promotes to entity types</rdfs:comment>
         <ont:enumValues>lead,prospect,customer,vendor,employee,partner</ont:enumValues>
         <ont:propertyType>enum</ont:propertyType>
     </owl:DatatypeProperty>
@@ -308,7 +308,7 @@
         <rdfs:label>status</rdfs:label>
         <rdfs:domain rdf:resource="http://example.org/ontology/elements-of-software/Task"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
-        <rdfs:comment>Lifecycle as a property, not a class per state</rdfs:comment>
+        <rdfs:comment>Lifecycle as a property, not an entity type per state</rdfs:comment>
         <ont:enumValues>todo,doing,blocked,done</ont:enumValues>
         <ont:propertyType>enum</ont:propertyType>
     </owl:DatatypeProperty>
@@ -480,7 +480,7 @@
         <rdfs:label>channel</rdfs:label>
         <rdfs:domain rdf:resource="http://example.org/ontology/elements-of-software/Interaction"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
-        <rdfs:comment>Email, call, meeting, chat — a property, not four classes</rdfs:comment>
+        <rdfs:comment>Email, call, meeting, chat — a property, not four entity types</rdfs:comment>
         <ont:enumValues>email,call,meeting,chat</ont:enumValues>
         <ont:propertyType>enum</ont:propertyType>
     </owl:DatatypeProperty>
@@ -658,7 +658,7 @@
         <rdfs:label>plays</rdfs:label>
         <rdfs:domain rdf:resource="http://example.org/ontology/elements-of-software/Party"/>
         <rdfs:range rdf:resource="http://example.org/ontology/elements-of-software/Role"/>
-        <rdfs:comment>Party plays Role: the pattern that replaces Lead, Customer and Vendor as classes</rdfs:comment>
+        <rdfs:comment>Party plays Role: the pattern that replaces Lead, Customer and Vendor as entity types</rdfs:comment>
         <ont:cardinality>one-to-many</ont:cardinality>
         <ont:fromEntityId>party</ont:fromEntityId>
         <ont:toEntityId>role</ont:toEntityId>
@@ -714,7 +714,7 @@
         <rdfs:label>subtask of</rdfs:label>
         <rdfs:domain rdf:resource="http://example.org/ontology/elements-of-software/Task"/>
         <rdfs:range rdf:resource="http://example.org/ontology/elements-of-software/Task"/>
-        <rdfs:comment>The self-relation that deletes the Subtask class: nesting is a relationship, not a kind</rdfs:comment>
+        <rdfs:comment>The self-relation that deletes the Subtask entity type: nesting is a relationship, not a kind</rdfs:comment>
         <ont:cardinality>many-to-one</ont:cardinality>
         <ont:fromEntityId>task</ont:fromEntityId>
         <ont:toEntityId>task</ont:toEntityId>

--- a/catalogue/community/daocoding/elements-of-software/elements-of-software.rdf
+++ b/catalogue/community/daocoding/elements-of-software/elements-of-software.rdf
@@ -1,0 +1,875 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rdf:RDF
+    xml:base="http://example.org/ontology/elements-of-software/"
+    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+    xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+    xmlns:owl="http://www.w3.org/2002/07/owl#"
+    xmlns:xsd="http://www.w3.org/2001/XMLSchema#"
+    xmlns:ont="http://example.org/ontology/elements-of-software/">
+
+    <owl:Ontology rdf:about="http://example.org/ontology/elements-of-software/">
+        <rdfs:label>Elements of Software</rdfs:label>
+        <rdfs:comment>The essential entities of any SaaS product, modeled with ontological discipline. Demonstrates the patterns that keep a schema honest: parties instead of person-shaped duplicates, roles as reified states rather than classes, one Task that nests, pipelines as properties rather than class chains, and views, automations, permissions and the audit trail as first-class records. Software agents are modeled as parties alongside people and organizations.</rdfs:comment>
+    </owl:Ontology>
+
+    <!-- ====================== -->
+    <!-- Entity Types (Classes) -->
+    <!-- ====================== -->
+
+    <owl:Class rdf:about="http://example.org/ontology/elements-of-software/Party">
+        <rdfs:label>Party</rdfs:label>
+        <rdfs:comment>Anyone who can act: a person, an organization, or a software agent. Relations that any actor may hold point here once — assign a Task to a Party and all three kinds qualify. This single abstraction removes most person-shaped duplicate classes from a schema.</rdfs:comment>
+        <ont:icon>🎭</ont:icon>
+        <ont:color>#5C2D91</ont:color>
+    </owl:Class>
+
+    <owl:Class rdf:about="http://example.org/ontology/elements-of-software/Person">
+        <rdfs:label>Person</rdfs:label>
+        <rdfs:comment>A human being. Note the modeling choice: an email address is a property of a Person; an email you send is an Interaction. Same word, two different kinds of thing.</rdfs:comment>
+        <ont:icon>👤</ont:icon>
+        <ont:color>#3498DB</ont:color>
+    </owl:Class>
+
+    <owl:Class rdf:about="http://example.org/ontology/elements-of-software/Organization">
+        <rdfs:label>Organization</rdfs:label>
+        <rdfs:comment>A company, institution, or other legal actor. Company, Account and Vendor are not three classes — they are one Organization playing three different Roles.</rdfs:comment>
+        <ont:icon>🏢</ont:icon>
+        <ont:color>#2E86AB</ont:color>
+    </owl:Class>
+
+    <owl:Class rdf:about="http://example.org/ontology/elements-of-software/Agent">
+        <rdfs:label>Agent</rdfs:label>
+        <rdfs:comment>A software actor. Modeled as a Party, not a feature: an agent holds tasks, sends interactions, and appears in the audit trail like anyone else. Every agent is operated by some Party — autonomy with a named principal.</rdfs:comment>
+        <ont:icon>🤖</ont:icon>
+        <ont:color>#8E44AD</ont:color>
+    </owl:Class>
+
+    <owl:Class rdf:about="http://example.org/ontology/elements-of-software/Role">
+        <rdfs:label>Role</rdfs:label>
+        <rdfs:comment>Lead, Customer, Vendor, Employee — not classes, but roles a Party plays for a while, in the context of some Organization. Reifying the role keeps one Person one node while their relationships change. Promoting roles to classes is the most common modeling mistake in business software.</rdfs:comment>
+        <ont:icon>🎫</ont:icon>
+        <ont:color>#9B59B6</ont:color>
+    </owl:Class>
+
+    <owl:Class rdf:about="http://example.org/ontology/elements-of-software/Team">
+        <rdfs:label>Team</rdfs:label>
+        <rdfs:comment>An organizational unit that owns work. People are members; teams belong to an Organization.</rdfs:comment>
+        <ont:icon>👥</ont:icon>
+        <ont:color>#16A085</ont:color>
+    </owl:Class>
+
+    <owl:Class rdf:about="http://example.org/ontology/elements-of-software/Project">
+        <rdfs:label>Project</rdfs:label>
+        <rdfs:comment>A bounded body of work with an owner and a lifecycle. Tasks belong to it; documents attach to it.</rdfs:comment>
+        <ont:icon>📁</ont:icon>
+        <ont:color>#27AE60</ont:color>
+    </owl:Class>
+
+    <owl:Class rdf:about="http://example.org/ontology/elements-of-software/Task">
+        <rdfs:label>Task</rdfs:label>
+        <rdfs:comment>A unit of work. One class with a parent relation replaces Task and Subtask — nesting is a relationship, not a new kind of thing. Assigned to a Party, so a person, a team's org, or an agent can hold it.</rdfs:comment>
+        <ont:icon>✅</ont:icon>
+        <ont:color>#2ECC71</ont:color>
+    </owl:Class>
+
+    <owl:Class rdf:about="http://example.org/ontology/elements-of-software/Document">
+        <rdfs:label>Document</rdfs:label>
+        <rdfs:comment>Doc, File, Note and Template are formats of one thing: authored content that attaches to work. The kind property distinguishes them; four classes would not.</rdfs:comment>
+        <ont:icon>📄</ont:icon>
+        <ont:color>#95A5A6</ont:color>
+    </owl:Class>
+
+    <owl:Class rdf:about="http://example.org/ontology/elements-of-software/Product">
+        <rdfs:label>Product</rdfs:label>
+        <rdfs:comment>What you sell. A Service is a Product you cannot drop on your foot; a Plan is a Product that recurs. One class, a kind property, and a price.</rdfs:comment>
+        <ont:icon>🧩</ont:icon>
+        <ont:color>#F39C12</ont:color>
+    </owl:Class>
+
+    <owl:Class rdf:about="http://example.org/ontology/elements-of-software/Deal">
+        <rdfs:label>Deal</rdfs:label>
+        <rdfs:comment>A potential transaction moving through a pipeline. The pipeline lives in the stage property — modeling Lead, Opportunity and Deal as separate classes forces a migration every time a prospect advances.</rdfs:comment>
+        <ont:icon>💼</ont:icon>
+        <ont:color>#E67E22</ont:color>
+    </owl:Class>
+
+    <owl:Class rdf:about="http://example.org/ontology/elements-of-software/Subscription">
+        <rdfs:label>Subscription</rdfs:label>
+        <rdfs:comment>An ongoing agreement binding a Party to a Product over time. The recurring-revenue chain reads directly off the graph: Subscription is billed by Invoices, Invoices are settled by Payments.</rdfs:comment>
+        <ont:icon>🔁</ont:icon>
+        <ont:color>#D4A017</ont:color>
+    </owl:Class>
+
+    <owl:Class rdf:about="http://example.org/ontology/elements-of-software/Invoice">
+        <rdfs:label>Invoice</rdfs:label>
+        <rdfs:comment>A demand for money owed under a Subscription. Has identity, lifecycle, and legal weight — a real entity, not a report.</rdfs:comment>
+        <ont:icon>🧾</ont:icon>
+        <ont:color>#C0A062</ont:color>
+    </owl:Class>
+
+    <owl:Class rdf:about="http://example.org/ontology/elements-of-software/Payment">
+        <rdfs:label>Payment</rdfs:label>
+        <rdfs:comment>Money actually moving. Settles an Invoice; the invoice-to-payment relation is where reconciliation lives.</rdfs:comment>
+        <ont:icon>💳</ont:icon>
+        <ont:color>#B7950B</ont:color>
+    </owl:Class>
+
+    <owl:Class rdf:about="http://example.org/ontology/elements-of-software/Interaction">
+        <rdfs:label>Interaction</rdfs:label>
+        <rdfs:comment>An email, call, meeting or chat message: one class, a channel property. Splitting these into four classes duplicates every relation they share — participants, timestamps, the deal they concern.</rdfs:comment>
+        <ont:icon>💬</ont:icon>
+        <ont:color>#E91E8C</ont:color>
+    </owl:Class>
+
+    <owl:Class rdf:about="http://example.org/ontology/elements-of-software/SavedView">
+        <rdfs:label>SavedView</rdfs:label>
+        <rdfs:comment>A Kanban board is not a thing in your domain — it is a way of looking at things. But a SAVED view is a real record: it has an owner, a filter, and a layout. The layout belongs in a property; the view belongs in the schema.</rdfs:comment>
+        <ont:icon>🗂️</ont:icon>
+        <ont:color>#7F8C8D</ont:color>
+    </owl:Class>
+
+    <owl:Class rdf:about="http://example.org/ontology/elements-of-software/Automation">
+        <rdfs:label>Automation</rdfs:label>
+        <rdfs:comment>A rule is data: when trigger, if condition, then action. Storing it as an entity means it can be owned, versioned, disabled and audited — automation you can hold accountable.</rdfs:comment>
+        <ont:icon>⚙️</ont:icon>
+        <ont:color>#34495E</ont:color>
+    </owl:Class>
+
+    <owl:Class rdf:about="http://example.org/ontology/elements-of-software/Permission">
+        <rdfs:label>Permission</rdfs:label>
+        <rdfs:comment>A grant of access: which Party may do how much to what kind of resource. Modeled as an entity so access is queryable — who can edit this, and since when.</rdfs:comment>
+        <ont:icon>🔐</ont:icon>
+        <ont:color>#5D6D7E</ont:color>
+    </owl:Class>
+
+    <owl:Class rdf:about="http://example.org/ontology/elements-of-software/AuditEvent">
+        <rdfs:label>AuditEvent</rdfs:label>
+        <rdfs:comment>The append-only memory of the system: who did what, when, to what. In software where agents act alongside people, the audit trail is what makes trust checkable rather than assumed.</rdfs:comment>
+        <ont:icon>📜</ont:icon>
+        <ont:color>#909497</ont:color>
+    </owl:Class>
+
+    <!-- =============== -->
+    <!-- Data Properties -->
+    <!-- =============== -->
+
+    <owl:DatatypeProperty rdf:about="http://example.org/ontology/elements-of-software/party_partyId">
+        <rdfs:label>partyId</rdfs:label>
+        <rdfs:domain rdf:resource="http://example.org/ontology/elements-of-software/Party"/>
+        <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
+        <rdfs:comment>One identifier for every kind of actor — person, organization or agent</rdfs:comment>
+        <ont:isIdentifier rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</ont:isIdentifier>
+        <ont:propertyType>string</ont:propertyType>
+    </owl:DatatypeProperty>
+
+    <owl:DatatypeProperty rdf:about="http://example.org/ontology/elements-of-software/party_displayName">
+        <rdfs:label>displayName</rdfs:label>
+        <rdfs:domain rdf:resource="http://example.org/ontology/elements-of-software/Party"/>
+        <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
+        <ont:propertyType>string</ont:propertyType>
+    </owl:DatatypeProperty>
+
+    <owl:DatatypeProperty rdf:about="http://example.org/ontology/elements-of-software/person_fullName">
+        <rdfs:label>fullName</rdfs:label>
+        <rdfs:domain rdf:resource="http://example.org/ontology/elements-of-software/Person"/>
+        <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
+        <ont:propertyType>string</ont:propertyType>
+    </owl:DatatypeProperty>
+
+    <owl:DatatypeProperty rdf:about="http://example.org/ontology/elements-of-software/person_emailAddress">
+        <rdfs:label>emailAddress</rdfs:label>
+        <rdfs:domain rdf:resource="http://example.org/ontology/elements-of-software/Person"/>
+        <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
+        <rdfs:comment>An address is a property; a message sent to it is an Interaction</rdfs:comment>
+        <ont:propertyType>string</ont:propertyType>
+    </owl:DatatypeProperty>
+
+    <owl:DatatypeProperty rdf:about="http://example.org/ontology/elements-of-software/person_phone">
+        <rdfs:label>phone</rdfs:label>
+        <rdfs:domain rdf:resource="http://example.org/ontology/elements-of-software/Person"/>
+        <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
+        <ont:propertyType>string</ont:propertyType>
+    </owl:DatatypeProperty>
+
+    <owl:DatatypeProperty rdf:about="http://example.org/ontology/elements-of-software/organization_legalName">
+        <rdfs:label>legalName</rdfs:label>
+        <rdfs:domain rdf:resource="http://example.org/ontology/elements-of-software/Organization"/>
+        <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
+        <ont:propertyType>string</ont:propertyType>
+    </owl:DatatypeProperty>
+
+    <owl:DatatypeProperty rdf:about="http://example.org/ontology/elements-of-software/organization_webDomain">
+        <rdfs:label>webDomain</rdfs:label>
+        <rdfs:domain rdf:resource="http://example.org/ontology/elements-of-software/Organization"/>
+        <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
+        <ont:propertyType>string</ont:propertyType>
+    </owl:DatatypeProperty>
+
+    <owl:DatatypeProperty rdf:about="http://example.org/ontology/elements-of-software/organization_size">
+        <rdfs:label>size</rdfs:label>
+        <rdfs:domain rdf:resource="http://example.org/ontology/elements-of-software/Organization"/>
+        <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
+        <ont:enumValues>solo,small,mid,enterprise</ont:enumValues>
+        <ont:propertyType>enum</ont:propertyType>
+    </owl:DatatypeProperty>
+
+    <owl:DatatypeProperty rdf:about="http://example.org/ontology/elements-of-software/agent_model">
+        <rdfs:label>model</rdfs:label>
+        <rdfs:domain rdf:resource="http://example.org/ontology/elements-of-software/Agent"/>
+        <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
+        <rdfs:comment>The underlying model or runtime this agent runs on</rdfs:comment>
+        <ont:propertyType>string</ont:propertyType>
+    </owl:DatatypeProperty>
+
+    <owl:DatatypeProperty rdf:about="http://example.org/ontology/elements-of-software/agent_purpose">
+        <rdfs:label>purpose</rdfs:label>
+        <rdfs:domain rdf:resource="http://example.org/ontology/elements-of-software/Agent"/>
+        <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
+        <ont:propertyType>string</ont:propertyType>
+    </owl:DatatypeProperty>
+
+    <owl:DatatypeProperty rdf:about="http://example.org/ontology/elements-of-software/agent_autonomyLevel">
+        <rdfs:label>autonomyLevel</rdfs:label>
+        <rdfs:domain rdf:resource="http://example.org/ontology/elements-of-software/Agent"/>
+        <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
+        <rdfs:comment>How far the agent may act before a person confirms</rdfs:comment>
+        <ont:enumValues>suggest,approve,autonomous</ont:enumValues>
+        <ont:propertyType>enum</ont:propertyType>
+    </owl:DatatypeProperty>
+
+    <owl:DatatypeProperty rdf:about="http://example.org/ontology/elements-of-software/role_kind">
+        <rdfs:label>kind</rdfs:label>
+        <rdfs:domain rdf:resource="http://example.org/ontology/elements-of-software/Role"/>
+        <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
+        <rdfs:comment>The role names that business software usually promotes to classes</rdfs:comment>
+        <ont:enumValues>lead,prospect,customer,vendor,employee,partner</ont:enumValues>
+        <ont:propertyType>enum</ont:propertyType>
+    </owl:DatatypeProperty>
+
+    <owl:DatatypeProperty rdf:about="http://example.org/ontology/elements-of-software/role_validFrom">
+        <rdfs:label>validFrom</rdfs:label>
+        <rdfs:domain rdf:resource="http://example.org/ontology/elements-of-software/Role"/>
+        <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#date"/>
+        <ont:propertyType>date</ont:propertyType>
+    </owl:DatatypeProperty>
+
+    <owl:DatatypeProperty rdf:about="http://example.org/ontology/elements-of-software/role_validTo">
+        <rdfs:label>validTo</rdfs:label>
+        <rdfs:domain rdf:resource="http://example.org/ontology/elements-of-software/Role"/>
+        <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#date"/>
+        <rdfs:comment>Roles end; people persist</rdfs:comment>
+        <ont:propertyType>date</ont:propertyType>
+    </owl:DatatypeProperty>
+
+    <owl:DatatypeProperty rdf:about="http://example.org/ontology/elements-of-software/team_teamName">
+        <rdfs:label>teamName</rdfs:label>
+        <rdfs:domain rdf:resource="http://example.org/ontology/elements-of-software/Team"/>
+        <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
+        <ont:propertyType>string</ont:propertyType>
+    </owl:DatatypeProperty>
+
+    <owl:DatatypeProperty rdf:about="http://example.org/ontology/elements-of-software/team_focus">
+        <rdfs:label>focus</rdfs:label>
+        <rdfs:domain rdf:resource="http://example.org/ontology/elements-of-software/Team"/>
+        <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
+        <ont:propertyType>string</ont:propertyType>
+    </owl:DatatypeProperty>
+
+    <owl:DatatypeProperty rdf:about="http://example.org/ontology/elements-of-software/project_projectName">
+        <rdfs:label>projectName</rdfs:label>
+        <rdfs:domain rdf:resource="http://example.org/ontology/elements-of-software/Project"/>
+        <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
+        <ont:propertyType>string</ont:propertyType>
+    </owl:DatatypeProperty>
+
+    <owl:DatatypeProperty rdf:about="http://example.org/ontology/elements-of-software/project_status">
+        <rdfs:label>status</rdfs:label>
+        <rdfs:domain rdf:resource="http://example.org/ontology/elements-of-software/Project"/>
+        <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
+        <ont:enumValues>active,paused,done</ont:enumValues>
+        <ont:propertyType>enum</ont:propertyType>
+    </owl:DatatypeProperty>
+
+    <owl:DatatypeProperty rdf:about="http://example.org/ontology/elements-of-software/project_startedAt">
+        <rdfs:label>startedAt</rdfs:label>
+        <rdfs:domain rdf:resource="http://example.org/ontology/elements-of-software/Project"/>
+        <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#date"/>
+        <ont:propertyType>date</ont:propertyType>
+    </owl:DatatypeProperty>
+
+    <owl:DatatypeProperty rdf:about="http://example.org/ontology/elements-of-software/task_title">
+        <rdfs:label>title</rdfs:label>
+        <rdfs:domain rdf:resource="http://example.org/ontology/elements-of-software/Task"/>
+        <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
+        <ont:propertyType>string</ont:propertyType>
+    </owl:DatatypeProperty>
+
+    <owl:DatatypeProperty rdf:about="http://example.org/ontology/elements-of-software/task_status">
+        <rdfs:label>status</rdfs:label>
+        <rdfs:domain rdf:resource="http://example.org/ontology/elements-of-software/Task"/>
+        <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
+        <rdfs:comment>Lifecycle as a property, not a class per state</rdfs:comment>
+        <ont:enumValues>todo,doing,blocked,done</ont:enumValues>
+        <ont:propertyType>enum</ont:propertyType>
+    </owl:DatatypeProperty>
+
+    <owl:DatatypeProperty rdf:about="http://example.org/ontology/elements-of-software/task_priority">
+        <rdfs:label>priority</rdfs:label>
+        <rdfs:domain rdf:resource="http://example.org/ontology/elements-of-software/Task"/>
+        <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
+        <ont:enumValues>low,normal,high,urgent</ont:enumValues>
+        <ont:propertyType>enum</ont:propertyType>
+    </owl:DatatypeProperty>
+
+    <owl:DatatypeProperty rdf:about="http://example.org/ontology/elements-of-software/task_dueAt">
+        <rdfs:label>dueAt</rdfs:label>
+        <rdfs:domain rdf:resource="http://example.org/ontology/elements-of-software/Task"/>
+        <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#dateTime"/>
+        <ont:propertyType>datetime</ont:propertyType>
+    </owl:DatatypeProperty>
+
+    <owl:DatatypeProperty rdf:about="http://example.org/ontology/elements-of-software/document_title">
+        <rdfs:label>title</rdfs:label>
+        <rdfs:domain rdf:resource="http://example.org/ontology/elements-of-software/Document"/>
+        <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
+        <ont:propertyType>string</ont:propertyType>
+    </owl:DatatypeProperty>
+
+    <owl:DatatypeProperty rdf:about="http://example.org/ontology/elements-of-software/document_kind">
+        <rdfs:label>kind</rdfs:label>
+        <rdfs:domain rdf:resource="http://example.org/ontology/elements-of-software/Document"/>
+        <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
+        <rdfs:comment>Doc, File, Note, Template: formats of one thing</rdfs:comment>
+        <ont:enumValues>doc,file,note,template</ont:enumValues>
+        <ont:propertyType>enum</ont:propertyType>
+    </owl:DatatypeProperty>
+
+    <owl:DatatypeProperty rdf:about="http://example.org/ontology/elements-of-software/document_updatedAt">
+        <rdfs:label>updatedAt</rdfs:label>
+        <rdfs:domain rdf:resource="http://example.org/ontology/elements-of-software/Document"/>
+        <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#dateTime"/>
+        <ont:propertyType>datetime</ont:propertyType>
+    </owl:DatatypeProperty>
+
+    <owl:DatatypeProperty rdf:about="http://example.org/ontology/elements-of-software/product_productName">
+        <rdfs:label>productName</rdfs:label>
+        <rdfs:domain rdf:resource="http://example.org/ontology/elements-of-software/Product"/>
+        <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
+        <ont:propertyType>string</ont:propertyType>
+    </owl:DatatypeProperty>
+
+    <owl:DatatypeProperty rdf:about="http://example.org/ontology/elements-of-software/product_kind">
+        <rdfs:label>kind</rdfs:label>
+        <rdfs:domain rdf:resource="http://example.org/ontology/elements-of-software/Product"/>
+        <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
+        <rdfs:comment>A Service is a Product you cannot drop on your foot; a Plan is a Product that recurs</rdfs:comment>
+        <ont:enumValues>good,service,plan</ont:enumValues>
+        <ont:propertyType>enum</ont:propertyType>
+    </owl:DatatypeProperty>
+
+    <owl:DatatypeProperty rdf:about="http://example.org/ontology/elements-of-software/product_price">
+        <rdfs:label>price</rdfs:label>
+        <rdfs:domain rdf:resource="http://example.org/ontology/elements-of-software/Product"/>
+        <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#decimal"/>
+        <ont:unit>USD</ont:unit>
+        <ont:propertyType>decimal</ont:propertyType>
+    </owl:DatatypeProperty>
+
+    <owl:DatatypeProperty rdf:about="http://example.org/ontology/elements-of-software/deal_stage">
+        <rdfs:label>stage</rdfs:label>
+        <rdfs:domain rdf:resource="http://example.org/ontology/elements-of-software/Deal"/>
+        <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
+        <rdfs:comment>The pipeline as a property — advancing a deal is an update, not a migration</rdfs:comment>
+        <ont:enumValues>qualifying,proposal,negotiation,won,lost</ont:enumValues>
+        <ont:propertyType>enum</ont:propertyType>
+    </owl:DatatypeProperty>
+
+    <owl:DatatypeProperty rdf:about="http://example.org/ontology/elements-of-software/deal_amount">
+        <rdfs:label>amount</rdfs:label>
+        <rdfs:domain rdf:resource="http://example.org/ontology/elements-of-software/Deal"/>
+        <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#decimal"/>
+        <ont:unit>USD</ont:unit>
+        <ont:propertyType>decimal</ont:propertyType>
+    </owl:DatatypeProperty>
+
+    <owl:DatatypeProperty rdf:about="http://example.org/ontology/elements-of-software/deal_probability">
+        <rdfs:label>probability</rdfs:label>
+        <rdfs:domain rdf:resource="http://example.org/ontology/elements-of-software/Deal"/>
+        <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#decimal"/>
+        <ont:unit>%</ont:unit>
+        <ont:propertyType>decimal</ont:propertyType>
+    </owl:DatatypeProperty>
+
+    <owl:DatatypeProperty rdf:about="http://example.org/ontology/elements-of-software/subscription_status">
+        <rdfs:label>status</rdfs:label>
+        <rdfs:domain rdf:resource="http://example.org/ontology/elements-of-software/Subscription"/>
+        <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
+        <ont:enumValues>trial,active,past_due,canceled</ont:enumValues>
+        <ont:propertyType>enum</ont:propertyType>
+    </owl:DatatypeProperty>
+
+    <owl:DatatypeProperty rdf:about="http://example.org/ontology/elements-of-software/subscription_startedAt">
+        <rdfs:label>startedAt</rdfs:label>
+        <rdfs:domain rdf:resource="http://example.org/ontology/elements-of-software/Subscription"/>
+        <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#date"/>
+        <ont:propertyType>date</ont:propertyType>
+    </owl:DatatypeProperty>
+
+    <owl:DatatypeProperty rdf:about="http://example.org/ontology/elements-of-software/subscription_renewsAt">
+        <rdfs:label>renewsAt</rdfs:label>
+        <rdfs:domain rdf:resource="http://example.org/ontology/elements-of-software/Subscription"/>
+        <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#date"/>
+        <ont:propertyType>date</ont:propertyType>
+    </owl:DatatypeProperty>
+
+    <owl:DatatypeProperty rdf:about="http://example.org/ontology/elements-of-software/invoice_invoiceNumber">
+        <rdfs:label>invoiceNumber</rdfs:label>
+        <rdfs:domain rdf:resource="http://example.org/ontology/elements-of-software/Invoice"/>
+        <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
+        <ont:isIdentifier rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</ont:isIdentifier>
+        <ont:propertyType>string</ont:propertyType>
+    </owl:DatatypeProperty>
+
+    <owl:DatatypeProperty rdf:about="http://example.org/ontology/elements-of-software/invoice_amount">
+        <rdfs:label>amount</rdfs:label>
+        <rdfs:domain rdf:resource="http://example.org/ontology/elements-of-software/Invoice"/>
+        <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#decimal"/>
+        <ont:unit>USD</ont:unit>
+        <ont:propertyType>decimal</ont:propertyType>
+    </owl:DatatypeProperty>
+
+    <owl:DatatypeProperty rdf:about="http://example.org/ontology/elements-of-software/invoice_status">
+        <rdfs:label>status</rdfs:label>
+        <rdfs:domain rdf:resource="http://example.org/ontology/elements-of-software/Invoice"/>
+        <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
+        <ont:enumValues>draft,sent,paid,void</ont:enumValues>
+        <ont:propertyType>enum</ont:propertyType>
+    </owl:DatatypeProperty>
+
+    <owl:DatatypeProperty rdf:about="http://example.org/ontology/elements-of-software/invoice_dueAt">
+        <rdfs:label>dueAt</rdfs:label>
+        <rdfs:domain rdf:resource="http://example.org/ontology/elements-of-software/Invoice"/>
+        <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#date"/>
+        <ont:propertyType>date</ont:propertyType>
+    </owl:DatatypeProperty>
+
+    <owl:DatatypeProperty rdf:about="http://example.org/ontology/elements-of-software/payment_amount">
+        <rdfs:label>amount</rdfs:label>
+        <rdfs:domain rdf:resource="http://example.org/ontology/elements-of-software/Payment"/>
+        <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#decimal"/>
+        <ont:unit>USD</ont:unit>
+        <ont:propertyType>decimal</ont:propertyType>
+    </owl:DatatypeProperty>
+
+    <owl:DatatypeProperty rdf:about="http://example.org/ontology/elements-of-software/payment_method">
+        <rdfs:label>method</rdfs:label>
+        <rdfs:domain rdf:resource="http://example.org/ontology/elements-of-software/Payment"/>
+        <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
+        <ont:enumValues>card,bank_transfer,cash,credit</ont:enumValues>
+        <ont:propertyType>enum</ont:propertyType>
+    </owl:DatatypeProperty>
+
+    <owl:DatatypeProperty rdf:about="http://example.org/ontology/elements-of-software/payment_paidAt">
+        <rdfs:label>paidAt</rdfs:label>
+        <rdfs:domain rdf:resource="http://example.org/ontology/elements-of-software/Payment"/>
+        <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#dateTime"/>
+        <ont:propertyType>datetime</ont:propertyType>
+    </owl:DatatypeProperty>
+
+    <owl:DatatypeProperty rdf:about="http://example.org/ontology/elements-of-software/interaction_channel">
+        <rdfs:label>channel</rdfs:label>
+        <rdfs:domain rdf:resource="http://example.org/ontology/elements-of-software/Interaction"/>
+        <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
+        <rdfs:comment>Email, call, meeting, chat — a property, not four classes</rdfs:comment>
+        <ont:enumValues>email,call,meeting,chat</ont:enumValues>
+        <ont:propertyType>enum</ont:propertyType>
+    </owl:DatatypeProperty>
+
+    <owl:DatatypeProperty rdf:about="http://example.org/ontology/elements-of-software/interaction_direction">
+        <rdfs:label>direction</rdfs:label>
+        <rdfs:domain rdf:resource="http://example.org/ontology/elements-of-software/Interaction"/>
+        <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
+        <ont:enumValues>inbound,outbound</ont:enumValues>
+        <ont:propertyType>enum</ont:propertyType>
+    </owl:DatatypeProperty>
+
+    <owl:DatatypeProperty rdf:about="http://example.org/ontology/elements-of-software/interaction_occurredAt">
+        <rdfs:label>occurredAt</rdfs:label>
+        <rdfs:domain rdf:resource="http://example.org/ontology/elements-of-software/Interaction"/>
+        <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#dateTime"/>
+        <ont:propertyType>datetime</ont:propertyType>
+    </owl:DatatypeProperty>
+
+    <owl:DatatypeProperty rdf:about="http://example.org/ontology/elements-of-software/interaction_summary">
+        <rdfs:label>summary</rdfs:label>
+        <rdfs:domain rdf:resource="http://example.org/ontology/elements-of-software/Interaction"/>
+        <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
+        <ont:propertyType>string</ont:propertyType>
+    </owl:DatatypeProperty>
+
+    <owl:DatatypeProperty rdf:about="http://example.org/ontology/elements-of-software/savedview_viewName">
+        <rdfs:label>viewName</rdfs:label>
+        <rdfs:domain rdf:resource="http://example.org/ontology/elements-of-software/SavedView"/>
+        <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
+        <ont:propertyType>string</ont:propertyType>
+    </owl:DatatypeProperty>
+
+    <owl:DatatypeProperty rdf:about="http://example.org/ontology/elements-of-software/savedview_layout">
+        <rdfs:label>layout</rdfs:label>
+        <rdfs:domain rdf:resource="http://example.org/ontology/elements-of-software/SavedView"/>
+        <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
+        <rdfs:comment>Kanban, list, calendar: ways of looking, so they live in a property</rdfs:comment>
+        <ont:enumValues>list,board,calendar,timeline,map</ont:enumValues>
+        <ont:propertyType>enum</ont:propertyType>
+    </owl:DatatypeProperty>
+
+    <owl:DatatypeProperty rdf:about="http://example.org/ontology/elements-of-software/savedview_filterQuery">
+        <rdfs:label>filterQuery</rdfs:label>
+        <rdfs:domain rdf:resource="http://example.org/ontology/elements-of-software/SavedView"/>
+        <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
+        <ont:propertyType>string</ont:propertyType>
+    </owl:DatatypeProperty>
+
+    <owl:DatatypeProperty rdf:about="http://example.org/ontology/elements-of-software/automation_name">
+        <rdfs:label>name</rdfs:label>
+        <rdfs:domain rdf:resource="http://example.org/ontology/elements-of-software/Automation"/>
+        <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
+        <ont:propertyType>string</ont:propertyType>
+    </owl:DatatypeProperty>
+
+    <owl:DatatypeProperty rdf:about="http://example.org/ontology/elements-of-software/automation_trigger">
+        <rdfs:label>trigger</rdfs:label>
+        <rdfs:domain rdf:resource="http://example.org/ontology/elements-of-software/Automation"/>
+        <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
+        <rdfs:comment>When: the event that wakes this rule</rdfs:comment>
+        <ont:propertyType>string</ont:propertyType>
+    </owl:DatatypeProperty>
+
+    <owl:DatatypeProperty rdf:about="http://example.org/ontology/elements-of-software/automation_condition">
+        <rdfs:label>condition</rdfs:label>
+        <rdfs:domain rdf:resource="http://example.org/ontology/elements-of-software/Automation"/>
+        <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
+        <rdfs:comment>If: the test that must hold before it acts</rdfs:comment>
+        <ont:propertyType>string</ont:propertyType>
+    </owl:DatatypeProperty>
+
+    <owl:DatatypeProperty rdf:about="http://example.org/ontology/elements-of-software/automation_action">
+        <rdfs:label>action</rdfs:label>
+        <rdfs:domain rdf:resource="http://example.org/ontology/elements-of-software/Automation"/>
+        <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
+        <rdfs:comment>Then: what it does</rdfs:comment>
+        <ont:propertyType>string</ont:propertyType>
+    </owl:DatatypeProperty>
+
+    <owl:DatatypeProperty rdf:about="http://example.org/ontology/elements-of-software/automation_enabled">
+        <rdfs:label>enabled</rdfs:label>
+        <rdfs:domain rdf:resource="http://example.org/ontology/elements-of-software/Automation"/>
+        <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#boolean"/>
+        <ont:propertyType>boolean</ont:propertyType>
+    </owl:DatatypeProperty>
+
+    <owl:DatatypeProperty rdf:about="http://example.org/ontology/elements-of-software/permission_level">
+        <rdfs:label>level</rdfs:label>
+        <rdfs:domain rdf:resource="http://example.org/ontology/elements-of-software/Permission"/>
+        <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
+        <ont:enumValues>view,comment,edit,admin</ont:enumValues>
+        <ont:propertyType>enum</ont:propertyType>
+    </owl:DatatypeProperty>
+
+    <owl:DatatypeProperty rdf:about="http://example.org/ontology/elements-of-software/permission_resourceKind">
+        <rdfs:label>resourceKind</rdfs:label>
+        <rdfs:domain rdf:resource="http://example.org/ontology/elements-of-software/Permission"/>
+        <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
+        <rdfs:comment>What kind of thing the grant covers, e.g. Project or Document</rdfs:comment>
+        <ont:propertyType>string</ont:propertyType>
+    </owl:DatatypeProperty>
+
+    <owl:DatatypeProperty rdf:about="http://example.org/ontology/elements-of-software/auditevent_verb">
+        <rdfs:label>verb</rdfs:label>
+        <rdfs:domain rdf:resource="http://example.org/ontology/elements-of-software/AuditEvent"/>
+        <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
+        <rdfs:comment>What was done: created, updated, deleted, approved, exported</rdfs:comment>
+        <ont:propertyType>string</ont:propertyType>
+    </owl:DatatypeProperty>
+
+    <owl:DatatypeProperty rdf:about="http://example.org/ontology/elements-of-software/auditevent_occurredAt">
+        <rdfs:label>occurredAt</rdfs:label>
+        <rdfs:domain rdf:resource="http://example.org/ontology/elements-of-software/AuditEvent"/>
+        <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#dateTime"/>
+        <ont:propertyType>datetime</ont:propertyType>
+    </owl:DatatypeProperty>
+
+    <owl:DatatypeProperty rdf:about="http://example.org/ontology/elements-of-software/auditevent_resourceKind">
+        <rdfs:label>resourceKind</rdfs:label>
+        <rdfs:domain rdf:resource="http://example.org/ontology/elements-of-software/AuditEvent"/>
+        <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
+        <ont:propertyType>string</ont:propertyType>
+    </owl:DatatypeProperty>
+
+    <owl:DatatypeProperty rdf:about="http://example.org/ontology/elements-of-software/auditevent_detail">
+        <rdfs:label>detail</rdfs:label>
+        <rdfs:domain rdf:resource="http://example.org/ontology/elements-of-software/AuditEvent"/>
+        <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
+        <ont:propertyType>string</ont:propertyType>
+    </owl:DatatypeProperty>
+
+    <!-- ======================= -->
+    <!-- Relationships (Verbs)   -->
+    <!-- ======================= -->
+
+    <owl:ObjectProperty rdf:about="http://example.org/ontology/elements-of-software/rel-person-is-a-party">
+        <rdfs:label>is a</rdfs:label>
+        <rdfs:domain rdf:resource="http://example.org/ontology/elements-of-software/Person"/>
+        <rdfs:range rdf:resource="http://example.org/ontology/elements-of-software/Party"/>
+        <rdfs:comment>A Person is a Party — the taxonomy drawn as an edge, since this format has no inheritance</rdfs:comment>
+        <ont:fromEntityId>person</ont:fromEntityId>
+        <ont:toEntityId>party</ont:toEntityId>
+    </owl:ObjectProperty>
+
+    <owl:ObjectProperty rdf:about="http://example.org/ontology/elements-of-software/rel-organization-is-a-party">
+        <rdfs:label>is a</rdfs:label>
+        <rdfs:domain rdf:resource="http://example.org/ontology/elements-of-software/Organization"/>
+        <rdfs:range rdf:resource="http://example.org/ontology/elements-of-software/Party"/>
+        <rdfs:comment>An Organization is a Party</rdfs:comment>
+        <ont:fromEntityId>organization</ont:fromEntityId>
+        <ont:toEntityId>party</ont:toEntityId>
+    </owl:ObjectProperty>
+
+    <owl:ObjectProperty rdf:about="http://example.org/ontology/elements-of-software/rel-agent-is-a-party">
+        <rdfs:label>is a</rdfs:label>
+        <rdfs:domain rdf:resource="http://example.org/ontology/elements-of-software/Agent"/>
+        <rdfs:range rdf:resource="http://example.org/ontology/elements-of-software/Party"/>
+        <rdfs:comment>An Agent is a Party — software actors participate on the same terms</rdfs:comment>
+        <ont:fromEntityId>agent</ont:fromEntityId>
+        <ont:toEntityId>party</ont:toEntityId>
+    </owl:ObjectProperty>
+
+    <owl:ObjectProperty rdf:about="http://example.org/ontology/elements-of-software/rel-agent-operated-by">
+        <rdfs:label>operated by</rdfs:label>
+        <rdfs:domain rdf:resource="http://example.org/ontology/elements-of-software/Agent"/>
+        <rdfs:range rdf:resource="http://example.org/ontology/elements-of-software/Party"/>
+        <rdfs:comment>Every agent answers to a principal</rdfs:comment>
+        <ont:cardinality>many-to-one</ont:cardinality>
+        <ont:fromEntityId>agent</ont:fromEntityId>
+        <ont:toEntityId>party</ont:toEntityId>
+    </owl:ObjectProperty>
+
+    <owl:ObjectProperty rdf:about="http://example.org/ontology/elements-of-software/rel-party-plays-role">
+        <rdfs:label>plays</rdfs:label>
+        <rdfs:domain rdf:resource="http://example.org/ontology/elements-of-software/Party"/>
+        <rdfs:range rdf:resource="http://example.org/ontology/elements-of-software/Role"/>
+        <rdfs:comment>Party plays Role: the pattern that replaces Lead, Customer and Vendor as classes</rdfs:comment>
+        <ont:cardinality>one-to-many</ont:cardinality>
+        <ont:fromEntityId>party</ont:fromEntityId>
+        <ont:toEntityId>role</ont:toEntityId>
+    </owl:ObjectProperty>
+
+    <owl:ObjectProperty rdf:about="http://example.org/ontology/elements-of-software/rel-role-at-organization">
+        <rdfs:label>at</rdfs:label>
+        <rdfs:domain rdf:resource="http://example.org/ontology/elements-of-software/Role"/>
+        <rdfs:range rdf:resource="http://example.org/ontology/elements-of-software/Organization"/>
+        <rdfs:comment>A role is played somewhere: you are a customer AT a company, an employee AT another</rdfs:comment>
+        <ont:cardinality>many-to-one</ont:cardinality>
+        <ont:fromEntityId>role</ont:fromEntityId>
+        <ont:toEntityId>organization</ont:toEntityId>
+    </owl:ObjectProperty>
+
+    <owl:ObjectProperty rdf:about="http://example.org/ontology/elements-of-software/rel-team-part-of">
+        <rdfs:label>part of</rdfs:label>
+        <rdfs:domain rdf:resource="http://example.org/ontology/elements-of-software/Team"/>
+        <rdfs:range rdf:resource="http://example.org/ontology/elements-of-software/Organization"/>
+        <ont:cardinality>many-to-one</ont:cardinality>
+        <ont:fromEntityId>team</ont:fromEntityId>
+        <ont:toEntityId>organization</ont:toEntityId>
+    </owl:ObjectProperty>
+
+    <owl:ObjectProperty rdf:about="http://example.org/ontology/elements-of-software/rel-person-member-of">
+        <rdfs:label>member of</rdfs:label>
+        <rdfs:domain rdf:resource="http://example.org/ontology/elements-of-software/Person"/>
+        <rdfs:range rdf:resource="http://example.org/ontology/elements-of-software/Team"/>
+        <ont:cardinality>many-to-many</ont:cardinality>
+        <ont:fromEntityId>person</ont:fromEntityId>
+        <ont:toEntityId>team</ont:toEntityId>
+    </owl:ObjectProperty>
+
+    <owl:ObjectProperty rdf:about="http://example.org/ontology/elements-of-software/rel-project-owned-by">
+        <rdfs:label>owned by</rdfs:label>
+        <rdfs:domain rdf:resource="http://example.org/ontology/elements-of-software/Project"/>
+        <rdfs:range rdf:resource="http://example.org/ontology/elements-of-software/Team"/>
+        <ont:cardinality>many-to-one</ont:cardinality>
+        <ont:fromEntityId>project</ont:fromEntityId>
+        <ont:toEntityId>team</ont:toEntityId>
+    </owl:ObjectProperty>
+
+    <owl:ObjectProperty rdf:about="http://example.org/ontology/elements-of-software/rel-task-belongs-to">
+        <rdfs:label>belongs to</rdfs:label>
+        <rdfs:domain rdf:resource="http://example.org/ontology/elements-of-software/Task"/>
+        <rdfs:range rdf:resource="http://example.org/ontology/elements-of-software/Project"/>
+        <ont:cardinality>many-to-one</ont:cardinality>
+        <ont:fromEntityId>task</ont:fromEntityId>
+        <ont:toEntityId>project</ont:toEntityId>
+    </owl:ObjectProperty>
+
+    <owl:ObjectProperty rdf:about="http://example.org/ontology/elements-of-software/rel-task-subtask-of">
+        <rdfs:label>subtask of</rdfs:label>
+        <rdfs:domain rdf:resource="http://example.org/ontology/elements-of-software/Task"/>
+        <rdfs:range rdf:resource="http://example.org/ontology/elements-of-software/Task"/>
+        <rdfs:comment>The self-relation that deletes the Subtask class: nesting is a relationship, not a kind</rdfs:comment>
+        <ont:cardinality>many-to-one</ont:cardinality>
+        <ont:fromEntityId>task</ont:fromEntityId>
+        <ont:toEntityId>task</ont:toEntityId>
+    </owl:ObjectProperty>
+
+    <owl:ObjectProperty rdf:about="http://example.org/ontology/elements-of-software/rel-task-assigned-to">
+        <rdfs:label>assigned to</rdfs:label>
+        <rdfs:domain rdf:resource="http://example.org/ontology/elements-of-software/Task"/>
+        <rdfs:range rdf:resource="http://example.org/ontology/elements-of-software/Party"/>
+        <rdfs:comment>Assigned to a Party — so a person or an agent can hold it, with no schema change</rdfs:comment>
+        <ont:cardinality>many-to-one</ont:cardinality>
+        <ont:fromEntityId>task</ont:fromEntityId>
+        <ont:toEntityId>party</ont:toEntityId>
+    </owl:ObjectProperty>
+
+    <owl:ObjectProperty rdf:about="http://example.org/ontology/elements-of-software/rel-document-attached-to">
+        <rdfs:label>attached to</rdfs:label>
+        <rdfs:domain rdf:resource="http://example.org/ontology/elements-of-software/Document"/>
+        <rdfs:range rdf:resource="http://example.org/ontology/elements-of-software/Project"/>
+        <ont:cardinality>many-to-one</ont:cardinality>
+        <ont:fromEntityId>document</ont:fromEntityId>
+        <ont:toEntityId>project</ont:toEntityId>
+    </owl:ObjectProperty>
+
+    <owl:ObjectProperty rdf:about="http://example.org/ontology/elements-of-software/rel-document-authored-by">
+        <rdfs:label>authored by</rdfs:label>
+        <rdfs:domain rdf:resource="http://example.org/ontology/elements-of-software/Document"/>
+        <rdfs:range rdf:resource="http://example.org/ontology/elements-of-software/Party"/>
+        <rdfs:comment>People and agents both write; the byline points at Party</rdfs:comment>
+        <ont:cardinality>many-to-one</ont:cardinality>
+        <ont:fromEntityId>document</ont:fromEntityId>
+        <ont:toEntityId>party</ont:toEntityId>
+    </owl:ObjectProperty>
+
+    <owl:ObjectProperty rdf:about="http://example.org/ontology/elements-of-software/rel-deal-with-party">
+        <rdfs:label>with</rdfs:label>
+        <rdfs:domain rdf:resource="http://example.org/ontology/elements-of-software/Deal"/>
+        <rdfs:range rdf:resource="http://example.org/ontology/elements-of-software/Party"/>
+        <rdfs:comment>The counterparty — a person or an organization, which is why it points at Party</rdfs:comment>
+        <ont:cardinality>many-to-one</ont:cardinality>
+        <ont:fromEntityId>deal</ont:fromEntityId>
+        <ont:toEntityId>party</ont:toEntityId>
+    </owl:ObjectProperty>
+
+    <owl:ObjectProperty rdf:about="http://example.org/ontology/elements-of-software/rel-deal-for-product">
+        <rdfs:label>for</rdfs:label>
+        <rdfs:domain rdf:resource="http://example.org/ontology/elements-of-software/Deal"/>
+        <rdfs:range rdf:resource="http://example.org/ontology/elements-of-software/Product"/>
+        <ont:cardinality>many-to-many</ont:cardinality>
+        <ont:fromEntityId>deal</ont:fromEntityId>
+        <ont:toEntityId>product</ont:toEntityId>
+    </owl:ObjectProperty>
+
+    <owl:ObjectProperty rdf:about="http://example.org/ontology/elements-of-software/rel-subscription-held-by">
+        <rdfs:label>held by</rdfs:label>
+        <rdfs:domain rdf:resource="http://example.org/ontology/elements-of-software/Subscription"/>
+        <rdfs:range rdf:resource="http://example.org/ontology/elements-of-software/Party"/>
+        <ont:cardinality>many-to-one</ont:cardinality>
+        <ont:fromEntityId>subscription</ont:fromEntityId>
+        <ont:toEntityId>party</ont:toEntityId>
+    </owl:ObjectProperty>
+
+    <owl:ObjectProperty rdf:about="http://example.org/ontology/elements-of-software/rel-subscription-for-product">
+        <rdfs:label>for</rdfs:label>
+        <rdfs:domain rdf:resource="http://example.org/ontology/elements-of-software/Subscription"/>
+        <rdfs:range rdf:resource="http://example.org/ontology/elements-of-software/Product"/>
+        <ont:cardinality>many-to-one</ont:cardinality>
+        <ont:fromEntityId>subscription</ont:fromEntityId>
+        <ont:toEntityId>product</ont:toEntityId>
+    </owl:ObjectProperty>
+
+    <owl:ObjectProperty rdf:about="http://example.org/ontology/elements-of-software/rel-invoice-bills">
+        <rdfs:label>bills</rdfs:label>
+        <rdfs:domain rdf:resource="http://example.org/ontology/elements-of-software/Invoice"/>
+        <rdfs:range rdf:resource="http://example.org/ontology/elements-of-software/Subscription"/>
+        <ont:cardinality>many-to-one</ont:cardinality>
+        <ont:fromEntityId>invoice</ont:fromEntityId>
+        <ont:toEntityId>subscription</ont:toEntityId>
+    </owl:ObjectProperty>
+
+    <owl:ObjectProperty rdf:about="http://example.org/ontology/elements-of-software/rel-payment-settles">
+        <rdfs:label>settles</rdfs:label>
+        <rdfs:domain rdf:resource="http://example.org/ontology/elements-of-software/Payment"/>
+        <rdfs:range rdf:resource="http://example.org/ontology/elements-of-software/Invoice"/>
+        <ont:cardinality>many-to-one</ont:cardinality>
+        <ont:fromEntityId>payment</ont:fromEntityId>
+        <ont:toEntityId>invoice</ont:toEntityId>
+    </owl:ObjectProperty>
+
+    <owl:ObjectProperty rdf:about="http://example.org/ontology/elements-of-software/rel-interaction-involves">
+        <rdfs:label>involves</rdfs:label>
+        <rdfs:domain rdf:resource="http://example.org/ontology/elements-of-software/Interaction"/>
+        <rdfs:range rdf:resource="http://example.org/ontology/elements-of-software/Party"/>
+        <rdfs:comment>Participants are Parties: a meeting of two people and an agent is one Interaction</rdfs:comment>
+        <ont:cardinality>many-to-many</ont:cardinality>
+        <ont:fromEntityId>interaction</ont:fromEntityId>
+        <ont:toEntityId>party</ont:toEntityId>
+    </owl:ObjectProperty>
+
+    <owl:ObjectProperty rdf:about="http://example.org/ontology/elements-of-software/rel-interaction-regarding">
+        <rdfs:label>regarding</rdfs:label>
+        <rdfs:domain rdf:resource="http://example.org/ontology/elements-of-software/Interaction"/>
+        <rdfs:range rdf:resource="http://example.org/ontology/elements-of-software/Deal"/>
+        <ont:cardinality>many-to-one</ont:cardinality>
+        <ont:fromEntityId>interaction</ont:fromEntityId>
+        <ont:toEntityId>deal</ont:toEntityId>
+    </owl:ObjectProperty>
+
+    <owl:ObjectProperty rdf:about="http://example.org/ontology/elements-of-software/rel-savedview-created-by">
+        <rdfs:label>created by</rdfs:label>
+        <rdfs:domain rdf:resource="http://example.org/ontology/elements-of-software/SavedView"/>
+        <rdfs:range rdf:resource="http://example.org/ontology/elements-of-software/Party"/>
+        <ont:cardinality>many-to-one</ont:cardinality>
+        <ont:fromEntityId>savedview</ont:fromEntityId>
+        <ont:toEntityId>party</ont:toEntityId>
+    </owl:ObjectProperty>
+
+    <owl:ObjectProperty rdf:about="http://example.org/ontology/elements-of-software/rel-automation-maintained-by">
+        <rdfs:label>maintained by</rdfs:label>
+        <rdfs:domain rdf:resource="http://example.org/ontology/elements-of-software/Automation"/>
+        <rdfs:range rdf:resource="http://example.org/ontology/elements-of-software/Party"/>
+        <rdfs:comment>Every rule has an owner you can ask why</rdfs:comment>
+        <ont:cardinality>many-to-one</ont:cardinality>
+        <ont:fromEntityId>automation</ont:fromEntityId>
+        <ont:toEntityId>party</ont:toEntityId>
+    </owl:ObjectProperty>
+
+    <owl:ObjectProperty rdf:about="http://example.org/ontology/elements-of-software/rel-automation-creates">
+        <rdfs:label>creates</rdfs:label>
+        <rdfs:domain rdf:resource="http://example.org/ontology/elements-of-software/Automation"/>
+        <rdfs:range rdf:resource="http://example.org/ontology/elements-of-software/Task"/>
+        <rdfs:comment>When it fires, work appears — and the AuditEvent says so</rdfs:comment>
+        <ont:cardinality>one-to-many</ont:cardinality>
+        <ont:fromEntityId>automation</ont:fromEntityId>
+        <ont:toEntityId>task</ont:toEntityId>
+    </owl:ObjectProperty>
+
+    <owl:ObjectProperty rdf:about="http://example.org/ontology/elements-of-software/rel-permission-granted-to">
+        <rdfs:label>granted to</rdfs:label>
+        <rdfs:domain rdf:resource="http://example.org/ontology/elements-of-software/Permission"/>
+        <rdfs:range rdf:resource="http://example.org/ontology/elements-of-software/Party"/>
+        <rdfs:comment>Access is granted to Parties — people and agents under one policy model</rdfs:comment>
+        <ont:cardinality>many-to-one</ont:cardinality>
+        <ont:fromEntityId>permission</ont:fromEntityId>
+        <ont:toEntityId>party</ont:toEntityId>
+    </owl:ObjectProperty>
+
+    <owl:ObjectProperty rdf:about="http://example.org/ontology/elements-of-software/rel-auditevent-performed-by">
+        <rdfs:label>performed by</rdfs:label>
+        <rdfs:domain rdf:resource="http://example.org/ontology/elements-of-software/AuditEvent"/>
+        <rdfs:range rdf:resource="http://example.org/ontology/elements-of-software/Party"/>
+        <rdfs:comment>Whoever acted — person, organization or agent — the trail reads the same</rdfs:comment>
+        <ont:cardinality>many-to-one</ont:cardinality>
+        <ont:fromEntityId>auditevent</ont:fromEntityId>
+        <ont:toEntityId>party</ont:toEntityId>
+    </owl:ObjectProperty>
+
+</rdf:RDF>

--- a/catalogue/community/daocoding/elements-of-software/metadata.json
+++ b/catalogue/community/daocoding/elements-of-software/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "Elements of Software",
-  "description": "The essential entities of any SaaS product, modeled with ontological discipline: people, organizations and software agents as interchangeable Parties; Lead and Customer as roles a Party plays rather than classes; one Task that nests; the subscription-invoice-payment chain; and saved views, automations, permissions and the audit trail as first-class records.",
+  "description": "The essential entities of any SaaS product, modeled with ontological discipline: people, organizations and software agents as interchangeable Parties; Lead and Customer as roles a Party plays rather than entity types; one Task that nests; the subscription-invoice-payment chain; and saved views, automations, permissions and the audit trail as first-class records.",
   "icon": "🧪",
   "category": "technology",
   "tags": ["saas", "patterns", "party-role", "crm", "modeling"],

--- a/catalogue/community/daocoding/elements-of-software/metadata.json
+++ b/catalogue/community/daocoding/elements-of-software/metadata.json
@@ -1,0 +1,8 @@
+{
+  "name": "Elements of Software",
+  "description": "The essential entities of any SaaS product, modeled with ontological discipline: people, organizations and software agents as interchangeable Parties; Lead and Customer as roles a Party plays rather than classes; one Task that nests; the subscription-invoice-payment chain; and saved views, automations, permissions and the audit trail as first-class records.",
+  "icon": "🧪",
+  "category": "technology",
+  "tags": ["saas", "patterns", "party-role", "crm", "modeling"],
+  "author": "daocoding"
+}


### PR DESCRIPTION
## What this adds

A community catalogue entry: **Elements of Software** — the essential entities of any SaaS product, modeled with ontological discipline. 19 entity types · 27 relationships · 60 properties.

`catalogue/community/daocoding/elements-of-software/`

## Why this ontology

Most business software re-invents the same schema, and usually re-invents the same modeling mistakes with it. This map shows the canonical patterns in one place, with each entity's description explaining the choice it embodies:

- **Party** — Person, Organization and software **Agent** as interchangeable actors. Relations any actor can hold (`assigned to`, `authored by`, `performed by`) point at Party once, instead of being duplicated per kind. Since the format has no inheritance, the taxonomy is drawn as explicit `is a` edges — which makes the pattern visible in the graph.
- **Role, reified** — Lead, Customer, Vendor and Employee as roles a Party *plays* over a time span (`validFrom`/`validTo`), rather than promoted to classes. Promoting roles to classes is the most common modeling mistake in CRM-shaped software.
- **One Task that nests** — a `subtask of` self-relation instead of a Subtask class.
- **Pipeline as a property** — Deal carries a `stage` enum; advancing a prospect is an update, not a migration across Lead/Opportunity/Deal classes.
- **The revenue chain on the graph** — Subscription *held by* Party, *billed by* Invoice, *settled by* Payment.
- **Views, rules and the trail as first-class records** — SavedView (a Kanban is a way of looking; a *saved* view is a record), Automation (`when / if / then` as data with an owner), Permission, and AuditEvent — with agents appearing in the audit trail on the same terms as people.

## Validation

- `npm run catalogue:build` succeeds — the entry compiles into `public/catalogue.json` (72 entries)
- `metadata.json` conforms to `catalogue/metadata-schema.json`
- RDF follows the existing community conventions (`ont:cardinality`, `ont:fromEntityId`/`ont:toEntityId`, `ont:propertyType`, `ont:enumValues`, `ont:isIdentifier`, `ont:unit`)
- `npm test`: 387 passed; the 7 failures in `src/lib/github.test.ts` are present on a clean checkout of `main` in my environment and are unrelated to this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)