### PR TITLE
Community ontology: Elements of Thinking (Paul-Elder critical thinking framework)

### DIFF
--- a/catalogue/community/daocoding/elements-of-thinking/elements-of-thinking.rdf
+++ b/catalogue/community/daocoding/elements-of-thinking/elements-of-thinking.rdf
@@ -88,7 +88,7 @@
 
     <owl:Class rdf:about="http://example.org/ontology/elements-of-thinking/IntellectualStandard">
         <rdfs:label>IntellectualStandard</rdfs:label>
-        <rdfs:comment>A yardstick applied to any element of any reasoning: clarity, accuracy, precision, relevance, depth, breadth, logic, significance, fairness. Each carries a probe question - could you elaborate? how could we check that? does it follow? - and the probes, not the names, do the work.</rdfs:comment>
+        <rdfs:comment>A yardstick applied to any element of any reasoning. Paul and Elder name nine as essential - clarity, accuracy, precision, relevance, depth, breadth, logic, significance, fairness - and say plainly that the list is a selection, not a fence: among others they name credibility, sufficiency, reliability, practicality. Each standard carries a probe question - could you elaborate? how could we check that? does it follow? - and the probes, not the names, do the work.</rdfs:comment>
         <ont:icon>📏</ont:icon>
         <ont:color>#8E44AD</ont:color>
     </owl:Class>

--- a/catalogue/community/daocoding/elements-of-thinking/elements-of-thinking.rdf
+++ b/catalogue/community/daocoding/elements-of-thinking/elements-of-thinking.rdf
@@ -1,0 +1,447 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rdf:RDF
+    xml:base="http://example.org/ontology/elements-of-thinking/"
+    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+    xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+    xmlns:owl="http://www.w3.org/2002/07/owl#"
+    xmlns:xsd="http://www.w3.org/2001/XMLSchema#"
+    xmlns:ont="http://example.org/ontology/elements-of-thinking/">
+
+    <owl:Ontology rdf:about="http://example.org/ontology/elements-of-thinking/">
+        <rdfs:label>Elements of Thinking</rdfs:label>
+        <rdfs:comment>An ontology of the Paul-Elder critical thinking framework: every act of reasoning carries eight elements of thought; nine intellectual standards measure their quality; practicing the standards until they become habit develops eight intellectual traits. Framework by Richard Paul and Linda Elder (Foundation for Critical Thinking, criticalthinking.org) - this ontology is an original modeling of it; their books go deeper.</rdfs:comment>
+    </owl:Ontology>
+
+    <!-- ====================== -->
+    <!-- Entity Types (Classes) -->
+    <!-- ====================== -->
+
+    <owl:Class rdf:about="http://example.org/ontology/elements-of-thinking/Reasoning">
+        <rdfs:label>Reasoning</rdfs:label>
+        <rdfs:comment>An act of figuring something out. Whenever it happens - an argument, a decision, a diagnosis, a plan - all eight elements of thought are present in it, named or not. Name them and the thinking becomes examinable.</rdfs:comment>
+        <ont:icon>🧠</ont:icon>
+        <ont:color>#D4A017</ont:color>
+    </owl:Class>
+
+    <owl:Class rdf:about="http://example.org/ontology/elements-of-thinking/Thinker">
+        <rdfs:label>Thinker</rdfs:label>
+        <rdfs:comment>The one doing the reasoning. Standards are applied by the thinker; traits grow in the thinker. The stage property tracks the Paul-Elder development ladder from unreflective to master - a ladder anyone can climb, and no one is born on top of.</rdfs:comment>
+        <ont:icon>🤔</ont:icon>
+        <ont:color>#E67E22</ont:color>
+    </owl:Class>
+
+    <owl:Class rdf:about="http://example.org/ontology/elements-of-thinking/Purpose">
+        <rdfs:label>Purpose</rdfs:label>
+        <rdfs:comment>What the thinking is for. Every act of reasoning serves a goal; when the goal is smuggled rather than stated, the reasoning serves it anyway - just unaccountably. The explicit flag asks: has it been said out loud?</rdfs:comment>
+        <ont:icon>🎯</ont:icon>
+        <ont:color>#2E86AB</ont:color>
+    </owl:Class>
+
+    <owl:Class rdf:about="http://example.org/ontology/elements-of-thinking/Question">
+        <rdfs:label>Question</rdfs:label>
+        <rdfs:comment>The question at issue. Paul and Elder distinguish three kinds: questions of fact (one right answer), of preference (as many answers as tastes), and of judgment (better and worse answers, argued for). Most stuck disagreements are two people blurring which kind is on the table.</rdfs:comment>
+        <ont:icon>❓</ont:icon>
+        <ont:color>#3498DB</ont:color>
+    </owl:Class>
+
+    <owl:Class rdf:about="http://example.org/ontology/elements-of-thinking/Information">
+        <rdfs:label>Information</rdfs:label>
+        <rdfs:comment>The data, facts, observations and experiences the reasoning draws on. Unverified information upstream becomes confident error downstream - the standards ask of it: accurate? relevant? sufficient?</rdfs:comment>
+        <ont:icon>📚</ont:icon>
+        <ont:color>#16A085</ont:color>
+    </owl:Class>
+
+    <owl:Class rdf:about="http://example.org/ontology/elements-of-thinking/Inference">
+        <rdfs:label>Inference</rdfs:label>
+        <rdfs:comment>The step from what you have to what you conclude - interpretation included. An inference is only as sound as the assumptions it stands on; the checked flag asks whether the leap itself was ever examined.</rdfs:comment>
+        <ont:icon>💡</ont:icon>
+        <ont:color>#1ABC9C</ont:color>
+    </owl:Class>
+
+    <owl:Class rdf:about="http://example.org/ontology/elements-of-thinking/Concept">
+        <rdfs:label>Concept</rdfs:label>
+        <rdfs:comment>The ideas, theories, definitions and models the thinking thinks WITH. Using a concept you cannot define is borrowing a tool you cannot hold - the defined flag keeps that honest.</rdfs:comment>
+        <ont:icon>🧩</ont:icon>
+        <ont:color>#5DADE2</ont:color>
+    </owl:Class>
+
+    <owl:Class rdf:about="http://example.org/ontology/elements-of-thinking/Assumption">
+        <rdfs:label>Assumption</rdfs:label>
+        <rdfs:comment>What is taken for granted. Every reasoning rests on assumptions; the danger is not having them - it is not knowing which ones are load-bearing. The examined flag: has this one been looked at in the light?</rdfs:comment>
+        <ont:icon>⚓</ont:icon>
+        <ont:color>#2C7FB8</ont:color>
+    </owl:Class>
+
+    <owl:Class rdf:about="http://example.org/ontology/elements-of-thinking/Implication">
+        <rdfs:label>Implication</rdfs:label>
+        <rdfs:comment>Where the reasoning leads once accepted - the consequences that follow whether or not they were wanted. Foreseen or unforeseen, they arrive; thinking them through beforehand is cheaper.</rdfs:comment>
+        <ont:icon>🌊</ont:icon>
+        <ont:color>#48C9B0</ont:color>
+    </owl:Class>
+
+    <owl:Class rdf:about="http://example.org/ontology/elements-of-thinking/PointOfView">
+        <rdfs:label>PointOfView</rdfs:label>
+        <rdfs:comment>The vantage the reasoning proceeds from - a frame that reveals some things and conceals others. No reasoning is frameless. The alternativesConsidered count is an honesty meter: how many other vantages were actually tried?</rdfs:comment>
+        <ont:icon>👁️</ont:icon>
+        <ont:color>#7FB3D5</ont:color>
+    </owl:Class>
+
+    <owl:Class rdf:about="http://example.org/ontology/elements-of-thinking/IntellectualStandard">
+        <rdfs:label>IntellectualStandard</rdfs:label>
+        <rdfs:comment>A yardstick applied to any element of any reasoning: clarity, accuracy, precision, relevance, depth, breadth, logic, significance, fairness. Each carries a probe question - could you elaborate? how could we check that? does it follow? - and the probes, not the names, do the work.</rdfs:comment>
+        <ont:icon>📏</ont:icon>
+        <ont:color>#8E44AD</ont:color>
+    </owl:Class>
+
+    <owl:Class rdf:about="http://example.org/ontology/elements-of-thinking/IntellectualTrait">
+        <rdfs:label>IntellectualTrait</rdfs:label>
+        <rdfs:comment>Character grown by applying the standards until they become disposition: humility, courage, empathy, autonomy, integrity, perseverance, confidence in reason, fairmindedness. Each displaces an opposing vice - humility displaces arrogance, courage displaces cowardice. Traits are the compound interest of practiced standards.</rdfs:comment>
+        <ont:icon>🌳</ont:icon>
+        <ont:color>#27AE60</ont:color>
+    </owl:Class>
+
+    <!-- =============== -->
+    <!-- Data Properties -->
+    <!-- =============== -->
+
+    <owl:DatatypeProperty rdf:about="http://example.org/ontology/elements-of-thinking/reasoning_about">
+        <rdfs:label>about</rdfs:label>
+        <rdfs:domain rdf:resource="http://example.org/ontology/elements-of-thinking/Reasoning"/>
+        <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
+        <rdfs:comment>What this act of thinking concerns</rdfs:comment>
+        <ont:propertyType>string</ont:propertyType>
+    </owl:DatatypeProperty>
+
+    <owl:DatatypeProperty rdf:about="http://example.org/ontology/elements-of-thinking/reasoning_context">
+        <rdfs:label>context</rdfs:label>
+        <rdfs:domain rdf:resource="http://example.org/ontology/elements-of-thinking/Reasoning"/>
+        <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
+        <ont:propertyType>string</ont:propertyType>
+    </owl:DatatypeProperty>
+
+    <owl:DatatypeProperty rdf:about="http://example.org/ontology/elements-of-thinking/thinker_thinkerId">
+        <rdfs:label>thinkerId</rdfs:label>
+        <rdfs:domain rdf:resource="http://example.org/ontology/elements-of-thinking/Thinker"/>
+        <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
+        <ont:isIdentifier rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</ont:isIdentifier>
+        <ont:propertyType>string</ont:propertyType>
+    </owl:DatatypeProperty>
+
+    <owl:DatatypeProperty rdf:about="http://example.org/ontology/elements-of-thinking/thinker_name">
+        <rdfs:label>name</rdfs:label>
+        <rdfs:domain rdf:resource="http://example.org/ontology/elements-of-thinking/Thinker"/>
+        <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
+        <ont:propertyType>string</ont:propertyType>
+    </owl:DatatypeProperty>
+
+    <owl:DatatypeProperty rdf:about="http://example.org/ontology/elements-of-thinking/thinker_stage">
+        <rdfs:label>stage</rdfs:label>
+        <rdfs:domain rdf:resource="http://example.org/ontology/elements-of-thinking/Thinker"/>
+        <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
+        <rdfs:comment>The Paul-Elder development ladder</rdfs:comment>
+        <ont:enumValues>unreflective,challenged,beginning,practicing,advanced,master</ont:enumValues>
+        <ont:propertyType>enum</ont:propertyType>
+    </owl:DatatypeProperty>
+
+    <owl:DatatypeProperty rdf:about="http://example.org/ontology/elements-of-thinking/purpose_statement">
+        <rdfs:label>statement</rdfs:label>
+        <rdfs:domain rdf:resource="http://example.org/ontology/elements-of-thinking/Purpose"/>
+        <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
+        <ont:propertyType>string</ont:propertyType>
+    </owl:DatatypeProperty>
+
+    <owl:DatatypeProperty rdf:about="http://example.org/ontology/elements-of-thinking/purpose_explicit">
+        <rdfs:label>explicit</rdfs:label>
+        <rdfs:domain rdf:resource="http://example.org/ontology/elements-of-thinking/Purpose"/>
+        <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#boolean"/>
+        <rdfs:comment>Stated out loud, or smuggled</rdfs:comment>
+        <ont:propertyType>boolean</ont:propertyType>
+    </owl:DatatypeProperty>
+
+    <owl:DatatypeProperty rdf:about="http://example.org/ontology/elements-of-thinking/question_statement">
+        <rdfs:label>statement</rdfs:label>
+        <rdfs:domain rdf:resource="http://example.org/ontology/elements-of-thinking/Question"/>
+        <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
+        <ont:propertyType>string</ont:propertyType>
+    </owl:DatatypeProperty>
+
+    <owl:DatatypeProperty rdf:about="http://example.org/ontology/elements-of-thinking/question_kind">
+        <rdfs:label>kind</rdfs:label>
+        <rdfs:domain rdf:resource="http://example.org/ontology/elements-of-thinking/Question"/>
+        <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
+        <rdfs:comment>Fact has one right answer; preference has many; judgment has better and worse, argued</rdfs:comment>
+        <ont:enumValues>fact,preference,judgment</ont:enumValues>
+        <ont:propertyType>enum</ont:propertyType>
+    </owl:DatatypeProperty>
+
+    <owl:DatatypeProperty rdf:about="http://example.org/ontology/elements-of-thinking/information_content">
+        <rdfs:label>content</rdfs:label>
+        <rdfs:domain rdf:resource="http://example.org/ontology/elements-of-thinking/Information"/>
+        <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
+        <ont:propertyType>string</ont:propertyType>
+    </owl:DatatypeProperty>
+
+    <owl:DatatypeProperty rdf:about="http://example.org/ontology/elements-of-thinking/information_source">
+        <rdfs:label>source</rdfs:label>
+        <rdfs:domain rdf:resource="http://example.org/ontology/elements-of-thinking/Information"/>
+        <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
+        <ont:propertyType>string</ont:propertyType>
+    </owl:DatatypeProperty>
+
+    <owl:DatatypeProperty rdf:about="http://example.org/ontology/elements-of-thinking/information_verified">
+        <rdfs:label>verified</rdfs:label>
+        <rdfs:domain rdf:resource="http://example.org/ontology/elements-of-thinking/Information"/>
+        <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#boolean"/>
+        <ont:propertyType>boolean</ont:propertyType>
+    </owl:DatatypeProperty>
+
+    <owl:DatatypeProperty rdf:about="http://example.org/ontology/elements-of-thinking/inference_conclusion">
+        <rdfs:label>conclusion</rdfs:label>
+        <rdfs:domain rdf:resource="http://example.org/ontology/elements-of-thinking/Inference"/>
+        <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
+        <ont:propertyType>string</ont:propertyType>
+    </owl:DatatypeProperty>
+
+    <owl:DatatypeProperty rdf:about="http://example.org/ontology/elements-of-thinking/inference_checked">
+        <rdfs:label>checked</rdfs:label>
+        <rdfs:domain rdf:resource="http://example.org/ontology/elements-of-thinking/Inference"/>
+        <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#boolean"/>
+        <rdfs:comment>Was the leap itself examined</rdfs:comment>
+        <ont:propertyType>boolean</ont:propertyType>
+    </owl:DatatypeProperty>
+
+    <owl:DatatypeProperty rdf:about="http://example.org/ontology/elements-of-thinking/concept_term">
+        <rdfs:label>term</rdfs:label>
+        <rdfs:domain rdf:resource="http://example.org/ontology/elements-of-thinking/Concept"/>
+        <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
+        <ont:propertyType>string</ont:propertyType>
+    </owl:DatatypeProperty>
+
+    <owl:DatatypeProperty rdf:about="http://example.org/ontology/elements-of-thinking/concept_defined">
+        <rdfs:label>defined</rdfs:label>
+        <rdfs:domain rdf:resource="http://example.org/ontology/elements-of-thinking/Concept"/>
+        <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#boolean"/>
+        <rdfs:comment>Can the thinker define the tool they are thinking with</rdfs:comment>
+        <ont:propertyType>boolean</ont:propertyType>
+    </owl:DatatypeProperty>
+
+    <owl:DatatypeProperty rdf:about="http://example.org/ontology/elements-of-thinking/assumption_statement">
+        <rdfs:label>statement</rdfs:label>
+        <rdfs:domain rdf:resource="http://example.org/ontology/elements-of-thinking/Assumption"/>
+        <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
+        <ont:propertyType>string</ont:propertyType>
+    </owl:DatatypeProperty>
+
+    <owl:DatatypeProperty rdf:about="http://example.org/ontology/elements-of-thinking/assumption_examined">
+        <rdfs:label>examined</rdfs:label>
+        <rdfs:domain rdf:resource="http://example.org/ontology/elements-of-thinking/Assumption"/>
+        <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#boolean"/>
+        <ont:propertyType>boolean</ont:propertyType>
+    </owl:DatatypeProperty>
+
+    <owl:DatatypeProperty rdf:about="http://example.org/ontology/elements-of-thinking/implication_statement">
+        <rdfs:label>statement</rdfs:label>
+        <rdfs:domain rdf:resource="http://example.org/ontology/elements-of-thinking/Implication"/>
+        <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
+        <ont:propertyType>string</ont:propertyType>
+    </owl:DatatypeProperty>
+
+    <owl:DatatypeProperty rdf:about="http://example.org/ontology/elements-of-thinking/implication_horizon">
+        <rdfs:label>horizon</rdfs:label>
+        <rdfs:domain rdf:resource="http://example.org/ontology/elements-of-thinking/Implication"/>
+        <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
+        <ont:enumValues>immediate,long_term</ont:enumValues>
+        <ont:propertyType>enum</ont:propertyType>
+    </owl:DatatypeProperty>
+
+    <owl:DatatypeProperty rdf:about="http://example.org/ontology/elements-of-thinking/implication_foreseen">
+        <rdfs:label>foreseen</rdfs:label>
+        <rdfs:domain rdf:resource="http://example.org/ontology/elements-of-thinking/Implication"/>
+        <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#boolean"/>
+        <ont:propertyType>boolean</ont:propertyType>
+    </owl:DatatypeProperty>
+
+    <owl:DatatypeProperty rdf:about="http://example.org/ontology/elements-of-thinking/pointofview_vantage">
+        <rdfs:label>vantage</rdfs:label>
+        <rdfs:domain rdf:resource="http://example.org/ontology/elements-of-thinking/PointOfView"/>
+        <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
+        <ont:propertyType>string</ont:propertyType>
+    </owl:DatatypeProperty>
+
+    <owl:DatatypeProperty rdf:about="http://example.org/ontology/elements-of-thinking/pointofview_alternativesConsidered">
+        <rdfs:label>alternativesConsidered</rdfs:label>
+        <rdfs:domain rdf:resource="http://example.org/ontology/elements-of-thinking/PointOfView"/>
+        <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#integer"/>
+        <rdfs:comment>An honesty meter: how many other vantages were actually tried</rdfs:comment>
+        <ont:propertyType>integer</ont:propertyType>
+    </owl:DatatypeProperty>
+
+    <owl:DatatypeProperty rdf:about="http://example.org/ontology/elements-of-thinking/intellectualstandard_name">
+        <rdfs:label>name</rdfs:label>
+        <rdfs:domain rdf:resource="http://example.org/ontology/elements-of-thinking/IntellectualStandard"/>
+        <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
+        <ont:enumValues>clarity,accuracy,precision,relevance,depth,breadth,logic,significance,fairness</ont:enumValues>
+        <ont:propertyType>enum</ont:propertyType>
+    </owl:DatatypeProperty>
+
+    <owl:DatatypeProperty rdf:about="http://example.org/ontology/elements-of-thinking/intellectualstandard_probe">
+        <rdfs:label>probe</rdfs:label>
+        <rdfs:domain rdf:resource="http://example.org/ontology/elements-of-thinking/IntellectualStandard"/>
+        <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
+        <rdfs:comment>The question this standard asks of a piece of thinking</rdfs:comment>
+        <ont:propertyType>string</ont:propertyType>
+    </owl:DatatypeProperty>
+
+    <owl:DatatypeProperty rdf:about="http://example.org/ontology/elements-of-thinking/intellectualtrait_name">
+        <rdfs:label>name</rdfs:label>
+        <rdfs:domain rdf:resource="http://example.org/ontology/elements-of-thinking/IntellectualTrait"/>
+        <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
+        <ont:enumValues>humility,courage,empathy,autonomy,integrity,perseverance,confidence_in_reason,fairmindedness</ont:enumValues>
+        <ont:propertyType>enum</ont:propertyType>
+    </owl:DatatypeProperty>
+
+    <owl:DatatypeProperty rdf:about="http://example.org/ontology/elements-of-thinking/intellectualtrait_opposite">
+        <rdfs:label>opposite</rdfs:label>
+        <rdfs:domain rdf:resource="http://example.org/ontology/elements-of-thinking/IntellectualTrait"/>
+        <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
+        <rdfs:comment>The vice this virtue displaces: arrogance, cowardice, closed-mindedness, conformity, hypocrisy, laziness, distrust of reason, unfairness</rdfs:comment>
+        <ont:propertyType>string</ont:propertyType>
+    </owl:DatatypeProperty>
+
+    <!-- ===================== -->
+    <!-- Relationships (Verbs) -->
+    <!-- ===================== -->
+
+    <owl:ObjectProperty rdf:about="http://example.org/ontology/elements-of-thinking/rel-thinker-performs">
+        <rdfs:label>performs</rdfs:label>
+        <rdfs:domain rdf:resource="http://example.org/ontology/elements-of-thinking/Thinker"/>
+        <rdfs:range rdf:resource="http://example.org/ontology/elements-of-thinking/Reasoning"/>
+        <ont:cardinality>one-to-many</ont:cardinality>
+        <ont:fromEntityId>thinker</ont:fromEntityId>
+        <ont:toEntityId>reasoning</ont:toEntityId>
+    </owl:ObjectProperty>
+
+    <owl:ObjectProperty rdf:about="http://example.org/ontology/elements-of-thinking/rel-reasoning-pursues">
+        <rdfs:label>pursues</rdfs:label>
+        <rdfs:domain rdf:resource="http://example.org/ontology/elements-of-thinking/Reasoning"/>
+        <rdfs:range rdf:resource="http://example.org/ontology/elements-of-thinking/Purpose"/>
+        <rdfs:comment>Every act of reasoning serves a goal, stated or not</rdfs:comment>
+        <ont:cardinality>many-to-one</ont:cardinality>
+        <ont:fromEntityId>reasoning</ont:fromEntityId>
+        <ont:toEntityId>purpose</ont:toEntityId>
+    </owl:ObjectProperty>
+
+    <owl:ObjectProperty rdf:about="http://example.org/ontology/elements-of-thinking/rel-reasoning-addresses">
+        <rdfs:label>addresses</rdfs:label>
+        <rdfs:domain rdf:resource="http://example.org/ontology/elements-of-thinking/Reasoning"/>
+        <rdfs:range rdf:resource="http://example.org/ontology/elements-of-thinking/Question"/>
+        <ont:cardinality>many-to-one</ont:cardinality>
+        <ont:fromEntityId>reasoning</ont:fromEntityId>
+        <ont:toEntityId>question</ont:toEntityId>
+    </owl:ObjectProperty>
+
+    <owl:ObjectProperty rdf:about="http://example.org/ontology/elements-of-thinking/rel-reasoning-draws-on">
+        <rdfs:label>draws on</rdfs:label>
+        <rdfs:domain rdf:resource="http://example.org/ontology/elements-of-thinking/Reasoning"/>
+        <rdfs:range rdf:resource="http://example.org/ontology/elements-of-thinking/Information"/>
+        <ont:cardinality>many-to-many</ont:cardinality>
+        <ont:fromEntityId>reasoning</ont:fromEntityId>
+        <ont:toEntityId>information</ont:toEntityId>
+    </owl:ObjectProperty>
+
+    <owl:ObjectProperty rdf:about="http://example.org/ontology/elements-of-thinking/rel-reasoning-draws">
+        <rdfs:label>draws</rdfs:label>
+        <rdfs:domain rdf:resource="http://example.org/ontology/elements-of-thinking/Reasoning"/>
+        <rdfs:range rdf:resource="http://example.org/ontology/elements-of-thinking/Inference"/>
+        <ont:cardinality>one-to-many</ont:cardinality>
+        <ont:fromEntityId>reasoning</ont:fromEntityId>
+        <ont:toEntityId>inference</ont:toEntityId>
+    </owl:ObjectProperty>
+
+    <owl:ObjectProperty rdf:about="http://example.org/ontology/elements-of-thinking/rel-reasoning-thinks-with">
+        <rdfs:label>thinks with</rdfs:label>
+        <rdfs:domain rdf:resource="http://example.org/ontology/elements-of-thinking/Reasoning"/>
+        <rdfs:range rdf:resource="http://example.org/ontology/elements-of-thinking/Concept"/>
+        <ont:cardinality>many-to-many</ont:cardinality>
+        <ont:fromEntityId>reasoning</ont:fromEntityId>
+        <ont:toEntityId>concept</ont:toEntityId>
+    </owl:ObjectProperty>
+
+    <owl:ObjectProperty rdf:about="http://example.org/ontology/elements-of-thinking/rel-reasoning-rests-on">
+        <rdfs:label>rests on</rdfs:label>
+        <rdfs:domain rdf:resource="http://example.org/ontology/elements-of-thinking/Reasoning"/>
+        <rdfs:range rdf:resource="http://example.org/ontology/elements-of-thinking/Assumption"/>
+        <rdfs:comment>The load-bearing ones matter most, and hide best</rdfs:comment>
+        <ont:cardinality>many-to-many</ont:cardinality>
+        <ont:fromEntityId>reasoning</ont:fromEntityId>
+        <ont:toEntityId>assumption</ont:toEntityId>
+    </owl:ObjectProperty>
+
+    <owl:ObjectProperty rdf:about="http://example.org/ontology/elements-of-thinking/rel-reasoning-leads-to">
+        <rdfs:label>leads to</rdfs:label>
+        <rdfs:domain rdf:resource="http://example.org/ontology/elements-of-thinking/Reasoning"/>
+        <rdfs:range rdf:resource="http://example.org/ontology/elements-of-thinking/Implication"/>
+        <ont:cardinality>one-to-many</ont:cardinality>
+        <ont:fromEntityId>reasoning</ont:fromEntityId>
+        <ont:toEntityId>implication</ont:toEntityId>
+    </owl:ObjectProperty>
+
+    <owl:ObjectProperty rdf:about="http://example.org/ontology/elements-of-thinking/rel-reasoning-proceeds-from">
+        <rdfs:label>proceeds from</rdfs:label>
+        <rdfs:domain rdf:resource="http://example.org/ontology/elements-of-thinking/Reasoning"/>
+        <rdfs:range rdf:resource="http://example.org/ontology/elements-of-thinking/PointOfView"/>
+        <ont:cardinality>many-to-one</ont:cardinality>
+        <ont:fromEntityId>reasoning</ont:fromEntityId>
+        <ont:toEntityId>pointofview</ont:toEntityId>
+    </owl:ObjectProperty>
+
+    <owl:ObjectProperty rdf:about="http://example.org/ontology/elements-of-thinking/rel-inference-answers">
+        <rdfs:label>answers</rdfs:label>
+        <rdfs:domain rdf:resource="http://example.org/ontology/elements-of-thinking/Inference"/>
+        <rdfs:range rdf:resource="http://example.org/ontology/elements-of-thinking/Question"/>
+        <rdfs:comment>The payoff edge: a conclusion is an answer offered to the question at issue</rdfs:comment>
+        <ont:cardinality>many-to-one</ont:cardinality>
+        <ont:fromEntityId>inference</ont:fromEntityId>
+        <ont:toEntityId>question</ont:toEntityId>
+    </owl:ObjectProperty>
+
+    <owl:ObjectProperty rdf:about="http://example.org/ontology/elements-of-thinking/rel-standard-measures">
+        <rdfs:label>measures</rdfs:label>
+        <rdfs:domain rdf:resource="http://example.org/ontology/elements-of-thinking/IntellectualStandard"/>
+        <rdfs:range rdf:resource="http://example.org/ontology/elements-of-thinking/Reasoning"/>
+        <rdfs:comment>Applied to each element in turn: is the purpose clear? the information accurate? the inference logical?</rdfs:comment>
+        <ont:cardinality>many-to-many</ont:cardinality>
+        <ont:fromEntityId>intellectualstandard</ont:fromEntityId>
+        <ont:toEntityId>reasoning</ont:toEntityId>
+    </owl:ObjectProperty>
+
+    <owl:ObjectProperty rdf:about="http://example.org/ontology/elements-of-thinking/rel-thinker-applies">
+        <rdfs:label>applies</rdfs:label>
+        <rdfs:domain rdf:resource="http://example.org/ontology/elements-of-thinking/Thinker"/>
+        <rdfs:range rdf:resource="http://example.org/ontology/elements-of-thinking/IntellectualStandard"/>
+        <ont:cardinality>many-to-many</ont:cardinality>
+        <ont:fromEntityId>thinker</ont:fromEntityId>
+        <ont:toEntityId>intellectualstandard</ont:toEntityId>
+    </owl:ObjectProperty>
+
+    <owl:ObjectProperty rdf:about="http://example.org/ontology/elements-of-thinking/rel-thinker-develops">
+        <rdfs:label>develops</rdfs:label>
+        <rdfs:domain rdf:resource="http://example.org/ontology/elements-of-thinking/Thinker"/>
+        <rdfs:range rdf:resource="http://example.org/ontology/elements-of-thinking/IntellectualTrait"/>
+        <rdfs:comment>Traits are not taught; they are grown by practicing the standards until they become disposition</rdfs:comment>
+        <ont:cardinality>one-to-many</ont:cardinality>
+        <ont:fromEntityId>thinker</ont:fromEntityId>
+        <ont:toEntityId>intellectualtrait</ont:toEntityId>
+    </owl:ObjectProperty>
+
+    <owl:ObjectProperty rdf:about="http://example.org/ontology/elements-of-thinking/rel-trait-steadies">
+        <rdfs:label>steadies</rdfs:label>
+        <rdfs:domain rdf:resource="http://example.org/ontology/elements-of-thinking/IntellectualTrait"/>
+        <rdfs:range rdf:resource="http://example.org/ontology/elements-of-thinking/Reasoning"/>
+        <rdfs:comment>The loop closes: developed character makes the next act of reasoning steadier than the last</rdfs:comment>
+        <ont:cardinality>many-to-many</ont:cardinality>
+        <ont:fromEntityId>intellectualtrait</ont:fromEntityId>
+        <ont:toEntityId>reasoning</ont:toEntityId>
+    </owl:ObjectProperty>
+
+</rdf:RDF>

--- a/catalogue/community/daocoding/elements-of-thinking/elements-of-thinking.rdf
+++ b/catalogue/community/daocoding/elements-of-thinking/elements-of-thinking.rdf
@@ -88,7 +88,7 @@
 
     <owl:Class rdf:about="http://example.org/ontology/elements-of-thinking/IntellectualStandard">
         <rdfs:label>IntellectualStandard</rdfs:label>
-        <rdfs:comment>A yardstick applied to any element of any reasoning. Paul and Elder name nine as essential - clarity, accuracy, precision, relevance, depth, breadth, logic, significance, fairness - and say plainly that the list is a selection, not a fence: among others they name credibility, sufficiency, reliability, practicality. Each standard carries a probe question - could you elaborate? how could we check that? does it follow? - and the probes, not the names, do the work.</rdfs:comment>
+        <rdfs:comment>A yardstick applied to any element of any reasoning. Paul and Elder name nine as essential - clarity, accuracy, precision, relevance, depth, breadth, logic, significance, fairness - and say plainly that the list is a selection, not a fence: among others they name credibility, sufficiency, reliability, practicality. The classic ten-standard chart rounds the list out with completeness, drawn from that tail; this map carries all ten. Each standard has a probe question - could you elaborate? how could we check that? does it follow? - and the probes, not the names, do the work.</rdfs:comment>
         <ont:icon>📏</ont:icon>
         <ont:color>#8E44AD</ont:color>
     </owl:Class>
@@ -280,7 +280,7 @@
         <rdfs:label>name</rdfs:label>
         <rdfs:domain rdf:resource="http://example.org/ontology/elements-of-thinking/IntellectualStandard"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
-        <ont:enumValues>clarity,accuracy,precision,relevance,depth,breadth,logic,significance,fairness</ont:enumValues>
+        <ont:enumValues>clarity,accuracy,precision,relevance,depth,breadth,logic,significance,fairness,completeness</ont:enumValues>
         <ont:propertyType>enum</ont:propertyType>
     </owl:DatatypeProperty>
 

--- a/catalogue/community/daocoding/elements-of-thinking/metadata.json
+++ b/catalogue/community/daocoding/elements-of-thinking/metadata.json
@@ -1,0 +1,8 @@
+{
+  "name": "Elements of Thinking",
+  "description": "An ontology of the Paul-Elder critical thinking framework (Richard Paul and Linda Elder, Foundation for Critical Thinking): every act of reasoning carries eight elements of thought - purpose, question, information, inference, concepts, assumptions, implications, point of view; nine intellectual standards measure their quality; practicing the standards develops eight intellectual traits. Includes the six-stage development ladder and each trait's opposing vice.",
+  "icon": "🧠",
+  "category": "education",
+  "tags": ["critical-thinking", "paul-elder", "reasoning", "metacognition", "education"],
+  "author": "daocoding"
+}


### PR DESCRIPTION
## What this adds

A community catalogue entry: **Elements of Thinking** — an ontology of the Paul–Elder critical thinking framework. 12 entity types · 14 relationships · 27 properties.

`catalogue/community/daocoding/elements-of-thinking/`

## The model

- **Reasoning** as the hub, with the framework's **eight elements of thought** radiating from it: Purpose, Question, Information, Inference, Concept, Assumption, Implication, PointOfView — each relation named as the framework describes it (*pursues*, *rests on*, *proceeds from*…).
- The **nine intellectual standards** (clarity, accuracy, precision, relevance, depth, breadth, logic, significance, fairness) and **eight intellectual traits** (humility, courage, empathy, autonomy, integrity, perseverance, confidence in reason, fairmindedness) are enum values on `IntellectualStandard` / `IntellectualTrait` — Clarity is an entity *of type* standard, and promoting each to its own entity type would blur the type/entity line.
- **The practice loop closes on the graph**: a Thinker *performs* Reasoning; Standards *measure* it; the Thinker *applies* Standards and *develops* Traits; the traits *steady* the next act of reasoning.
- Properties carry the rest of the framework: the six-stage development ladder (`thinker.stage`), the fact/preference/judgment question taxonomy (`question.kind`), each trait's opposing vice, and honesty flags (`explicit`, `examined`, `checked`, `verified`, `alternativesConsidered`).

## Attribution

Framework by **Richard Paul and Linda Elder** (Foundation for Critical Thinking, [criticalthinking.org](https://www.criticalthinking.org)) — credited in the ontology header, metadata and descriptions. All descriptive text is original; their books go deeper.

## Validation

- `npm run catalogue:build` succeeds — the entry compiles into `public/catalogue.json` (72 entries)
- `metadata.json` conforms to `catalogue/metadata-schema.json` (category: `education`)
- RDF follows existing community conventions (`ont:cardinality`, `ont:fromEntityId`/`ont:toEntityId`, `ont:propertyType`, `ont:enumValues`, `ont:isIdentifier`)

Sibling PR from the same author: #86 (Elements of Software).

🤖 Generated with [Claude Code](https://claude.com/claude-code)