### PR TITLE
fix(graph): make the entity type legend collapsible

### DIFF
--- a/src/components/GraphLegend.test.tsx
+++ b/src/components/GraphLegend.test.tsx
@@ -1,0 +1,119 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { GraphLegend, LEGEND_AUTO_COLLAPSE_THRESHOLD } from './GraphLegend';
+import type { EntityType } from '../data/ontology';
+
+const STORAGE_KEY = 'ontology-legend-collapsed';
+
+function makeEntityTypes(count: number): EntityType[] {
+  return Array.from({ length: count }, (_, index) => ({
+    id: `entity-${index}`,
+    name: `Entity ${index}`,
+    description: `Entity ${index} description`,
+    properties: [],
+    icon: '📦',
+    color: '#0078D4',
+  }));
+}
+
+const toggleButton = () => screen.getByRole('button', { name: /Entity Types legend/i });
+
+describe('GraphLegend', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    vi.restoreAllMocks();
+  });
+
+  it('lists every entity type when expanded', () => {
+    render(<GraphLegend entityTypes={makeEntityTypes(3)} />);
+
+    expect(toggleButton()).toHaveAttribute('aria-expanded', 'true');
+    expect(screen.getByText('📦 Entity 0')).toBeInTheDocument();
+    expect(screen.getByText('📦 Entity 2')).toBeInTheDocument();
+  });
+
+  it('collapses the legend off the canvas and remembers the choice', () => {
+    render(<GraphLegend entityTypes={makeEntityTypes(3)} />);
+
+    fireEvent.click(toggleButton());
+
+    expect(toggleButton()).toHaveAttribute('aria-expanded', 'false');
+    expect(screen.queryByText('📦 Entity 0')).not.toBeInTheDocument();
+    // The title stays visible so the collapsed legend is still findable.
+    expect(screen.getByText('Entity Types')).toBeInTheDocument();
+    expect(localStorage.getItem(STORAGE_KEY)).toBe('true');
+  });
+
+  it('re-expands and persists that choice too', () => {
+    render(<GraphLegend entityTypes={makeEntityTypes(3)} />);
+
+    fireEvent.click(toggleButton());
+    fireEvent.click(toggleButton());
+
+    expect(toggleButton()).toHaveAttribute('aria-expanded', 'true');
+    expect(screen.getByText('📦 Entity 0')).toBeInTheDocument();
+    expect(localStorage.getItem(STORAGE_KEY)).toBe('false');
+  });
+
+  it('shows the entity type count while collapsed', () => {
+    render(<GraphLegend entityTypes={makeEntityTypes(7)} />);
+
+    fireEvent.click(toggleButton());
+
+    expect(screen.getByText('7')).toBeInTheDocument();
+  });
+
+  it('starts collapsed for an ontology large enough to bury the graph', () => {
+    render(<GraphLegend entityTypes={makeEntityTypes(LEGEND_AUTO_COLLAPSE_THRESHOLD + 1)} />);
+
+    expect(toggleButton()).toHaveAttribute('aria-expanded', 'false');
+    expect(screen.queryByText('📦 Entity 0')).not.toBeInTheDocument();
+  });
+
+  it('starts expanded at the threshold', () => {
+    render(<GraphLegend entityTypes={makeEntityTypes(LEGEND_AUTO_COLLAPSE_THRESHOLD)} />);
+
+    expect(toggleButton()).toHaveAttribute('aria-expanded', 'true');
+  });
+
+  it('honours a stored preference over the size heuristic', () => {
+    localStorage.setItem(STORAGE_KEY, 'false');
+
+    render(<GraphLegend entityTypes={makeEntityTypes(LEGEND_AUTO_COLLAPSE_THRESHOLD + 50)} />);
+
+    expect(toggleButton()).toHaveAttribute('aria-expanded', 'true');
+  });
+
+  it('collapses when a large ontology is loaded into an open session', () => {
+    const { rerender } = render(<GraphLegend entityTypes={makeEntityTypes(3)} />);
+    expect(toggleButton()).toHaveAttribute('aria-expanded', 'true');
+
+    rerender(<GraphLegend entityTypes={makeEntityTypes(LEGEND_AUTO_COLLAPSE_THRESHOLD + 100)} />);
+
+    expect(toggleButton()).toHaveAttribute('aria-expanded', 'false');
+  });
+
+  it('keeps an explicit choice when a large ontology is loaded', () => {
+    const { rerender } = render(<GraphLegend entityTypes={makeEntityTypes(3)} />);
+
+    fireEvent.click(toggleButton()); // collapse
+    fireEvent.click(toggleButton()); // expand — now an explicit preference
+    rerender(<GraphLegend entityTypes={makeEntityTypes(LEGEND_AUTO_COLLAPSE_THRESHOLD + 100)} />);
+
+    expect(toggleButton()).toHaveAttribute('aria-expanded', 'true');
+  });
+
+  it('still toggles when localStorage is unavailable', () => {
+    vi.spyOn(Storage.prototype, 'getItem').mockImplementation(() => {
+      throw new Error('localStorage disabled');
+    });
+    vi.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
+      throw new Error('localStorage disabled');
+    });
+
+    render(<GraphLegend entityTypes={makeEntityTypes(3)} />);
+
+    expect(() => fireEvent.click(toggleButton())).not.toThrow();
+    expect(toggleButton()).toHaveAttribute('aria-expanded', 'false');
+  });
+});

--- a/src/components/GraphLegend.tsx
+++ b/src/components/GraphLegend.tsx
@@ -1,0 +1,89 @@
+import { useEffect, useState } from 'react';
+import { ChevronDown, ChevronUp } from 'lucide-react';
+import type { EntityType } from '../data/ontology';
+
+const STORAGE_KEY = 'ontology-legend-collapsed';
+
+/**
+ * Above this many entity types an expanded legend blankets the canvas, so it
+ * opens collapsed instead. Imported taxonomies routinely exceed this — Brick
+ * 1.4 alone carries over 1,500 classes.
+ */
+export const LEGEND_AUTO_COLLAPSE_THRESHOLD = 12;
+
+/** Returns the stored preference, or null when the user has never toggled it. */
+function readStoredCollapsed(): boolean | null {
+  try {
+    const stored = localStorage.getItem(STORAGE_KEY);
+    if (stored === 'true') return true;
+    if (stored === 'false') return false;
+  } catch { /* localStorage unavailable */ }
+  return null;
+}
+
+function defaultCollapsed(entityTypeCount: number): boolean {
+  const stored = readStoredCollapsed();
+  if (stored !== null) return stored;
+  return entityTypeCount > LEGEND_AUTO_COLLAPSE_THRESHOLD;
+}
+
+interface GraphLegendProps {
+  entityTypes: EntityType[];
+}
+
+/**
+ * Entity-type key overlaid on the graph canvas. Collapsible so it can be moved
+ * out of the way of the nodes it sits on top of, remembering the choice across
+ * sessions.
+ */
+export function GraphLegend({ entityTypes }: GraphLegendProps) {
+  const entityTypeCount = entityTypes.length;
+  const [collapsed, setCollapsed] = useState(() => defaultCollapsed(entityTypeCount));
+
+  // Loading a much larger ontology re-applies the size heuristic, so importing
+  // a big taxonomy into an open session doesn't bury the graph. An explicit
+  // user choice still wins.
+  useEffect(() => {
+    if (readStoredCollapsed() !== null) return;
+    setCollapsed(entityTypeCount > LEGEND_AUTO_COLLAPSE_THRESHOLD);
+  }, [entityTypeCount]);
+
+  const toggle = () => {
+    setCollapsed(previous => {
+      const next = !previous;
+      try { localStorage.setItem(STORAGE_KEY, String(next)); } catch { /* noop */ }
+      return next;
+    });
+  };
+
+  return (
+    <div className={`graph-legend ${collapsed ? 'graph-legend--collapsed' : ''}`}>
+      <button
+        type="button"
+        className="legend-toggle"
+        onClick={toggle}
+        aria-expanded={!collapsed}
+        aria-controls="graph-legend-body"
+        // Keeps the visible "Entity Types" label inside the accessible name
+        // (WCAG 2.5.3) while still saying what the button does.
+        aria-label={collapsed ? 'Show Entity Types legend' : 'Hide Entity Types legend'}
+        title={collapsed ? 'Show Entity Types legend' : 'Hide Entity Types legend'}
+      >
+        <span className="legend-title">Entity Types</span>
+        <span className="legend-count">{entityTypeCount}</span>
+        {collapsed ? <ChevronUp size={14} /> : <ChevronDown size={14} />}
+      </button>
+
+      {!collapsed && (
+        <div id="graph-legend-body" className="legend-body">
+          {entityTypes.map(entity => (
+            <div key={entity.id} className="legend-item">
+              <div className="legend-dot" style={{ backgroundColor: entity.color }} />
+              <span>{entity.icon} {entity.name}</span>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/OntologyGraph.tsx
+++ b/src/components/OntologyGraph.tsx
@@ -4,6 +4,7 @@ import fcose from 'cytoscape-fcose';
 import type { Core, EventObject, LayoutOptions } from 'cytoscape';
 import { useAppStore } from '../store/appStore';
 import { ZoomIn, ZoomOut, Maximize2, RotateCcw, Download, Crosshair } from 'lucide-react';
+import { GraphLegend } from './GraphLegend';
 
 // Register fcose layout
 cytoscape.use(fcose);
@@ -576,15 +577,7 @@ export function OntologyGraph() {
         </button>
       </div>
 
-      <div className="graph-legend">
-        <div className="legend-title">Entity Types</div>
-        {currentOntology.entityTypes.map(entity => (
-          <div key={entity.id} className="legend-item">
-            <div className="legend-dot" style={{ backgroundColor: entity.color }} />
-            <span>{entity.icon} {entity.name}</span>
-          </div>
-        ))}
-      </div>
+      <GraphLegend entityTypes={currentOntology.entityTypes} />
     </div>
   );
 }

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -765,8 +765,49 @@ body {
   background: var(--bg-elevated);
   border: 1px solid var(--border-color);
   border-radius: var(--radius-lg);
-  padding: 16px;
   min-width: 180px;
+  /* Never let a large ontology's legend blanket the canvas it sits on. */
+  max-height: 45%;
+  display: flex;
+  flex-direction: column;
+}
+
+.legend-toggle {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+  padding: 14px 16px;
+  background: none;
+  border: none;
+  border-radius: var(--radius-lg);
+  font-family: inherit;
+  text-align: left;
+  cursor: pointer;
+  color: var(--text-secondary);
+  flex-shrink: 0;
+}
+
+.legend-toggle:hover {
+  color: var(--text-primary);
+}
+
+.legend-toggle:focus-visible {
+  outline: 2px solid var(--ms-blue);
+  outline-offset: -2px;
+}
+
+.legend-count {
+  margin-left: auto;
+  font-size: 11px;
+  font-weight: 600;
+  font-variant-numeric: tabular-nums;
+  color: var(--text-secondary);
+}
+
+.legend-body {
+  padding: 0 16px 14px;
+  overflow-y: auto;
 }
 
 .legend-title {
@@ -774,7 +815,6 @@ body {
   font-weight: 600;
   color: var(--text-secondary);
   text-transform: uppercase;
-  margin-bottom: 12px;
 }
 
 .legend-item {


### PR DESCRIPTION
Fixes the first item of #87 — "a popup or overlay appears over the graph and obscures the nodes. I could not find an option to close, minimize, or move it."

## The problem

The entity-type legend is absolutely positioned over the graph canvas and renders **one row per entity type with no bound**:

```tsx
<div className="graph-legend">
  <div className="legend-title">Entity Types</div>
  {currentOntology.entityTypes.map(entity => ( ... ))}
</div>
```

There is no close, collapse, or move affordance anywhere — the only place it gets hidden is the mobile breakpoint, which drops it with `display: none`. On a large ontology it grows until it blankets the nodes it exists to annotate, which is what the reporter's screenshot shows.

## The change

- **Collapsible.** A header button collapses the legend to a single pill showing the title and the entity-type count. The choice persists to `localStorage`, so it survives a reload.
- **Sensible default for big ontologies.** With no stored preference, the legend opens collapsed above `LEGEND_AUTO_COLLAPSE_THRESHOLD` (12) entity types, and re-applies that heuristic when a much larger ontology is loaded into an already-open session — so importing a big taxonomy doesn't bury the graph. An explicit toggle always wins over the heuristic.
- **Bounded.** The expanded body is capped at 45% of canvas height with internal scrolling, so even an unbounded entity list can't cover the graph.

Extracted into `GraphLegend.tsx` — it now owns state, and `OntologyGraph` is already ~590 lines and mounts cytoscape on render, which makes it impractical to reach in jsdom. `OntologyGraph`'s diff is a one-line swap.

**Accessibility:** the toggle carries `aria-expanded` / `aria-controls`, plus an `aria-label` that keeps the visible "Entity Types" text inside the accessible name (WCAG 2.5.3) — without it the button announced as "Entity Types3". Only existing theme tokens are used, so the contrast suite is unaffected.

## Verification

10 new unit tests in `GraphLegend.test.tsx` cover expand/collapse, persistence, the size heuristic, explicit-choice precedence, mid-session ontology growth, and `localStorage` being unavailable.

Also driven against the running app with Playwright:

| Scenario | Result |
|---|---|
| Default ontology (6 types) | opens expanded, all 6 rows |
| Click toggle | collapses to the pill, 0 rows, persisted |
| Reload | still collapsed |
| `community/1010yab/university-class-search` (19 types) | opens collapsed |
| Expanding it | 376px tall inside an 836px canvas, all 19 rows scrollable |

No console errors in any state.

## Notes

- Scoped to item 1 of #87. Item 3 (empty PNG export) is already covered by #95; item 2 (navigating large graphs) is a bigger design question I left alone.
- Independent of #108 — no overlapping files.
- `npm test` on this branch shows one unrelated pre-existing failure, `compile-catalogue.test.ts` timing out under Vitest's 5s default, which is what #108 fixes.
