### PR TITLE
fix(a11y): give the graph and its controls accessible names

### DIFF
--- a/src/components/OntologyGraph.tsx
+++ b/src/components/OntologyGraph.tsx
@@ -3,6 +3,7 @@ import cytoscape from 'cytoscape';
 import fcose from 'cytoscape-fcose';
 import type { Core, EventObject, LayoutOptions } from 'cytoscape';
 import { useAppStore } from '../store/appStore';
+import { describeOntologyGraph } from '../lib/graphA11y';
 import { ZoomIn, ZoomOut, Maximize2, RotateCcw, Download, Crosshair } from 'lucide-react';
 
 // Register fcose layout
@@ -539,7 +540,13 @@ export function OntologyGraph() {
 
   return (
     <div className="graph-container">
-      <div ref={containerRef} className="graph-canvas" data-testid="ontology-graph-canvas" />
+      <div
+        ref={containerRef}
+        className="graph-canvas"
+        data-testid="ontology-graph-canvas"
+        role="img"
+        aria-label={describeOntologyGraph(currentOntology)}
+      />
 
       {focusNodeId && (
         <div className="graph-focus-badge">
@@ -559,19 +566,19 @@ export function OntologyGraph() {
       )}
       
       <div className="graph-controls">
-        <button className="graph-control-btn" onClick={handleZoomIn} title="Zoom In">
+        <button className="graph-control-btn" onClick={handleZoomIn} title="Zoom In" aria-label="Zoom in">
           <ZoomIn size={18} />
         </button>
-        <button className="graph-control-btn" onClick={handleZoomOut} title="Zoom Out">
+        <button className="graph-control-btn" onClick={handleZoomOut} title="Zoom Out" aria-label="Zoom out">
           <ZoomOut size={18} />
         </button>
-        <button className="graph-control-btn" onClick={handleFit} title="Fit to View">
+        <button className="graph-control-btn" onClick={handleFit} title="Fit to View" aria-label="Fit graph to view">
           <Maximize2 size={18} />
         </button>
-        <button className="graph-control-btn" onClick={handleReset} title="Reset Layout">
+        <button className="graph-control-btn" onClick={handleReset} title="Reset Layout" aria-label="Reset graph layout">
           <RotateCcw size={18} />
         </button>
-        <button className="graph-control-btn" onClick={handleDownload} title="Download Graph as PNG" data-testid="download-ontology-png">
+        <button className="graph-control-btn" onClick={handleDownload} title="Download Graph as PNG" aria-label="Download graph as PNG" data-testid="download-ontology-png">
           <Download size={18} />
         </button>
       </div>

--- a/src/lib/graphA11y.test.ts
+++ b/src/lib/graphA11y.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from 'vitest';
+import { describeOntologyGraph } from './graphA11y';
+import type { EntityType, Ontology, Relationship } from '../data/ontology';
+
+function entityTypes(count: number): EntityType[] {
+  return Array.from({ length: count }, (_, index) => ({
+    id: `entity-${index}`,
+    name: `Entity ${index}`,
+    description: '',
+    properties: [],
+    icon: '📦',
+    color: '#0078D4',
+  }));
+}
+
+function relationships(count: number): Relationship[] {
+  return Array.from({ length: count }, (_, index) => ({
+    id: `rel-${index}`,
+    name: `relates${index}`,
+    from: 'entity-0',
+    to: 'entity-0',
+    cardinality: 'one-to-many' as const,
+  }));
+}
+
+function ontology(name: string, entities: number, rels: number): Ontology {
+  return {
+    name,
+    description: '',
+    entityTypes: entityTypes(entities),
+    relationships: relationships(rels),
+  };
+}
+
+describe('describeOntologyGraph', () => {
+  it('names the ontology and counts what the canvas shows', () => {
+    expect(describeOntologyGraph(ontology('Fourth Coffee', 6, 7))).toBe(
+      'Fourth Coffee ontology graph: 6 entity types, 7 relationships. Interactive diagram.',
+    );
+  });
+
+  it('uses singular nouns for a count of one', () => {
+    expect(describeOntologyGraph(ontology('Tiny', 1, 1))).toContain('1 entity type, 1 relationship.');
+  });
+
+  it('describes an empty ontology without crashing', () => {
+    expect(describeOntologyGraph(ontology('Blank', 0, 0))).toBe(
+      'Blank ontology graph: 0 entity types, 0 relationships. Interactive diagram.',
+    );
+  });
+
+  it('falls back to a generic subject when the ontology is unnamed', () => {
+    expect(describeOntologyGraph(ontology('', 2, 1))).toBe(
+      'Ontology graph: 2 entity types, 1 relationship. Interactive diagram.',
+    );
+  });
+
+  it('ignores a whitespace-only ontology name', () => {
+    expect(describeOntologyGraph(ontology('   ', 2, 1))).toBe(
+      'Ontology graph: 2 entity types, 1 relationship. Interactive diagram.',
+    );
+  });
+});

--- a/src/lib/graphA11y.ts
+++ b/src/lib/graphA11y.ts
@@ -1,0 +1,23 @@
+import type { Ontology } from '../data/ontology';
+
+function pluralize(count: number, noun: string): string {
+  return `${count} ${noun}${count === 1 ? '' : 's'}`;
+}
+
+/**
+ * Accessible name for the graph canvas.
+ *
+ * Cytoscape paints the ontology into `<canvas>` elements, which expose nothing
+ * to assistive technology — without this the graph is an unlabelled region and
+ * a screen reader announces nothing at all for the app's central feature. The
+ * container carries `role="img"` and this summary as its label; the entity and
+ * relationship names themselves stay reachable in the search panel and legend
+ * rather than being duplicated into one long label.
+ */
+export function describeOntologyGraph(ontology: Ontology): string {
+  const name = ontology.name?.trim();
+  const subject = name ? `${name} ontology graph` : 'Ontology graph';
+  const entityTypes = pluralize(ontology.entityTypes.length, 'entity type');
+  const relationships = pluralize(ontology.relationships.length, 'relationship');
+  return `${subject}: ${entityTypes}, ${relationships}. Interactive diagram.`;
+}


### PR DESCRIPTION
Picks up the unchecked "Add ARIA labels to the graph visualization" item from `TODO.md`, continuing the recent accessibility work (#75, #77, #78).

## The problem

Cytoscape paints the ontology into `<canvas>` elements, which expose nothing to assistive technology. The container is a bare div:

```tsx
<div ref={containerRef} className="graph-canvas" data-testid="ontology-graph-canvas" />
```

No role, no label, no text alternative — a screen reader announces **nothing at all** for the app's central feature.

## The change

**The graph canvas** gets `role="img"` and an accessible name built from the loaded ontology — name, entity-type count, relationship count:

> "Fourth Coffee ontology graph: 6 entity types, 7 relationships. Interactive diagram."

Two deliberate choices there:

- The role goes on `.graph-canvas`, not `.graph-container`. `role="img"` prunes descendants from the accessibility tree, and the container also holds the legend and the control buttons — putting it there would have hidden them.
- Entity and relationship *names* are not folded into the label. They're already reachable as real DOM in the search panel and the legend, and a paragraph-long accessible name reads badly.

The summary lives in `src/lib/graphA11y.ts` as a pure function, so it's testable without mounting cytoscape in jsdom.

**The five control buttons** are icon-only and carried only a `title`. To be precise: `title` *does* supply an accessible name for an icon-only button, so this wasn't a violation — but it's the fragile option, announced inconsistently across screen readers and invisible on touch. They now carry explicit `aria-label`s, with `title` kept for the mouse tooltip.

## Verification

5 unit tests cover the summary: counts, singular/plural agreement, an empty ontology, and the unnamed/whitespace-name fallback.

Driven against the running app with Playwright:

| Check | Result |
|---|---|
| Canvas exposes `role="img"` | yes, 1 match |
| Accessible name | "Fourth Coffee ontology graph: 6 entity types, 7 relationships. Interactive diagram." |
| Label tracks the loaded ontology | switches to "E-Commerce Platform ontology graph: 5 entity types, 6 relationships." |
| All 5 controls resolvable by accessible name | yes — and they activate correctly when clicked by name |

No console errors. Only existing theme tokens are involved, so the contrast suite is untouched.

## Scope

- **Keyboard navigation of the graph** is a separate unchecked TODO item and is deliberately not addressed here — it's a design question, not a labelling one.
- Independent of #108 and #109. #109 also touches `OntologyGraph.tsx`, but a different region (the legend), so they merge cleanly in either order.
- `npm test` on this branch shows one unrelated pre-existing failure — `compile-catalogue.test.ts` timing out under Vitest's 5s default — which is what #108 fixes.
